### PR TITLE
Event display

### DIFF
--- a/NtupleProducer/plugins/NtupleProducer.cc
+++ b/NtupleProducer/plugins/NtupleProducer.cc
@@ -190,6 +190,7 @@ NtupleProducer::NtupleProducer(const edm::ParameterSet& iConfig):
   produces<PFOutputCollection>("RawCalo");
   produces<PFOutputCollection>("Calo");
   produces<PFOutputCollection>("PF");
+  produces<PFOutputCollection>("Puppi");
   TokGenPar_       = consumesCollector().mayConsume<reco::GenParticleCollection>( GenParTag_    );
   TokL1TrackTPTag_ = consumesCollector().mayConsume<L1PFCollection>( L1TrackTag_  );
   TokEcalTPTag_    = consumesCollector().mayConsume<L1PFCollection>( EcalTPTag_   );
@@ -496,6 +497,7 @@ NtupleProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   addPF(lCorrCalo,"Calo"    ,iEvent);
   addPF(lTKCands ,"TK"      ,iEvent);
   addPF(lCands   ,"PF"      ,iEvent);
+  addPF(lPupCands,"Puppi"   ,iEvent);
   
   metanalyzer_->clear();
   metanalyzer_->setZ(lTKCands,connector_->dZ());

--- a/NtupleProducer/python/display/drawers.py
+++ b/NtupleProducer/python/display/drawers.py
@@ -1,0 +1,156 @@
+import ROOT, copy, string
+
+class AbsCollectionDrawer(object):
+    def __init__(self,filter=None):
+        self.filter = filter
+    def drawOne(self,index,object):
+        pass
+    def draw(self,objs):
+        for i,o in enumerate(objs):
+            if self.filter and not self.filter(o): 
+                continue
+            self.drawOne(i+1,o)
+        return True
+    def clone(self, name):
+        raise RuntimeError, "Not implemented"
+
+class MultiGraphMarkerDrawerVsPt(AbsCollectionDrawer):
+    def __init__(self,markerStyle=20,markerColor=1,markerSizes=[2],ptEdges=[0,9e9],maxItems=99999,filter=None):
+        AbsCollectionDrawer.__init__(self,filter)
+        self._markers = [ ]
+        for i,markerSize in enumerate(markerSizes):
+            marker = ROOT.TGraph()
+            marker.SetMarkerStyle(markerStyle)
+            marker.SetMarkerColor(markerColor)
+            marker.SetMarkerSize(markerSize)
+            marker.ptEdges = (ptEdges[i],ptEdges[i+1])
+            self._markers.append(marker)
+        self._maxItems = maxItems
+    def draw(self,objs):
+        todraw = [[] for m in self._markers]
+        for o in objs:
+            if self.filter and not self.filter(o): 
+                continue
+            for im,m in enumerate(self._markers):
+                if o.pt() < m.ptEdges[0]: break
+                if o.pt() < m.ptEdges[1]:
+                    todraw[im].append(o)
+                    break
+        for im,m in enumerate(self._markers):
+            if len(todraw[im]) == 0: continue
+            m.Set(len(todraw[im]))
+            for i,o in enumerate(todraw[im]):
+                m.SetPoint(i, o.eta(), o.phi()) 
+            m.Draw("P")
+        return True
+    def clone(self, name):
+        ret = copy.copy(self)
+        ret._markers = [ g.Clone() for g in self._markers ]
+        for src,dst in zip(self._markers, ret._markers): dst.ptEdges = src.ptEdges[:]
+        return ret
+
+class CircleDrawer(AbsCollectionDrawer):
+    def __init__(self,radius,lineColor=1,lineWidth=2,lineStyle=1,maxItems=99,filter=None):
+        AbsCollectionDrawer.__init__(self,filter)
+        self._radius = radius
+        self._circle = ROOT.TEllipse(0,0,radius)
+        self._circle.SetLineColor(lineColor)
+        self._circle.SetLineWidth(lineWidth)
+        self._circle.SetLineStyle(lineStyle)
+        self._circle.SetFillStyle(0)
+        self._maxItems = maxItems
+    def drawOne(self,index,object):
+        if (index >= self._maxItems): return
+        self._circle.DrawEllipse(object.eta(),object.phi(),self._radius,self._radius,0.,360.,0.)
+    def clone(self, name):
+        return copy.copy(self)
+
+class CanvasMaker(object):
+    def __init__(self,maxEvents=100,maxEta=5,vlines=[]):
+        ROOT.gROOT.ProcessLine(".x tdrstyle.cc");
+        ROOT.gStyle.SetPaperSize(25.,25*(3.14/maxEta))
+        self._maxEta = maxEta
+        self._canvas = ROOT.TCanvas("c1","c1",int((2*maxEta)*1.7*100), int(6.28*1.7*100));
+        self._canvas.SetWindowSize(int((2*maxEta)*1.7*100), int(6.28*1.7*100))
+        self._canvas.SetGridx(1)
+        self._canvas.SetGridy(1)
+        self._frame = ROOT.TH1F("frame","frame;#eta;#phi",1000,-maxEta,maxEta);
+        self._frame.GetYaxis().SetRangeUser(-3.1416,3.1416);
+        self._frame.SetStats(0);
+        self._maxEvents = maxEvents
+        self._currEvents = 0
+        self._vlines = vlines 
+        self._tvline = ROOT.TLine(0,0,1,1)
+        self._tvline.SetLineWidth(3)
+        self._tvline.SetLineStyle(7)
+    def canvas(self): 
+        return self._canvas
+    def go(self,event):
+        self._currEvents += 1;
+        if self._currEvents > self._maxEvents: return False
+        self.clear();
+        return True
+    def clear(self):
+        self._canvas.Clear()
+        self._frame.GetYaxis().SetRangeUser(-3.1416,3.1416);
+        self._frame.GetXaxis().SetRangeUser(-self._maxEta,self._maxEta);
+        self._frame.Draw()
+        for x in self._vlines:
+            self._tvline.DrawLine(x, -3.1416, x, +3.1416)
+    def zoom(self,center,radius):
+        xmin, xmax = max(center[0]-radius,-self._maxEta), min(center[0]+radius,self._maxEta)
+        ymin, ymax = max(center[1]-radius,-3.1416), min(center[1]+radius,+3.1416)
+        self._frame.Draw()
+        self._frame.GetXaxis().SetRangeUser(xmin,xmax);
+        self._frame.GetYaxis().SetRangeUser(ymin,ymax);
+        for x in self._vlines:
+            if (xmin < x and x < xmax): self._tvline.DrawLine(x, ymin, x, ymax)
+    def done(self,event):
+        for template in self._fileTemplate:
+            self.write(event,template) 
+        return True
+    def write(self,event,template):
+        fname = string.Formatter().vformat(template,[],{'run':event.eventAuxiliary().run(), 'lumi':event.eventAuxiliary().luminosityBlock(), 'evt':event.eventAuxiliary().event()})
+        self._canvas.Print(fname)
+        print fname
+
+
+cMaker  = CanvasMaker(maxEta=5, vlines=[-4,-3,-1.5,1.5,3,4])
+drawGenJets = [ CircleDrawer(0.4, lineColor=ROOT.kAzure+1,  lineStyle=1) ]
+
+ptEdges = [0.3,1.0,2.5,9e9]
+drawGenCands = [
+    MultiGraphMarkerDrawerVsPt( filter = lambda d : d.charge() != 0,                          markerStyle=34, markerSizes=[1.1,1.4,1.7], ptEdges=ptEdges, markerColor=ROOT.kRed+2 ),
+    MultiGraphMarkerDrawerVsPt( filter = lambda d : d.charge() == 0 and abs(d.pdgId()) == 22, markerStyle=34, markerSizes=[1.1,1.4,1.7], ptEdges=ptEdges, markerColor=ROOT.kGreen+3 ),
+    MultiGraphMarkerDrawerVsPt( filter = lambda d : d.charge() == 0 and abs(d.pdgId()) != 22, markerStyle=34, markerSizes=[1.1,1.4,1.7], ptEdges=ptEdges, markerColor=ROOT.kBlue+2 ),
+]
+drawTracks   = [ MultiGraphMarkerDrawerVsPt( markerStyle=20, markerSizes=[0.8,1.2,1.5], ptEdges=ptEdges, markerColor=ROOT.kViolet+1 ), ]
+drawHcal     = [ MultiGraphMarkerDrawerVsPt( markerStyle=21, markerSizes=[0.8,1.2,1.5], ptEdges=ptEdges, markerColor=ROOT.kAzure+1 ), ]
+drawEcal     = [ MultiGraphMarkerDrawerVsPt( markerStyle=21, markerSizes=[0.8,1.2,1.5], ptEdges=ptEdges, markerColor=ROOT.kGreen+1 ), ]
+drawHGCalE   = [ MultiGraphMarkerDrawerVsPt( markerStyle=21, markerSizes=[0.8,1.2,1.5], ptEdges=ptEdges, markerColor=ROOT.kOrange-3 ), ]
+drawHGCalH   = [ MultiGraphMarkerDrawerVsPt( markerStyle=21, markerSizes=[0.8,1.2,1.5], ptEdges=ptEdges, markerColor=ROOT.kAzure+1 ), ]
+drawHGCalB   = [ MultiGraphMarkerDrawerVsPt( markerStyle=21, markerSizes=[0.8,1.2,1.5], ptEdges=ptEdges, markerColor=ROOT.kMagenta ), ]
+
+drawCaloCands = [
+    MultiGraphMarkerDrawerVsPt( filter = lambda d : d.charge() != 0,                          markerStyle=25, markerSizes=[1.2,1.5,1.8], ptEdges=ptEdges, markerColor=ROOT.kRed-9 ),
+    MultiGraphMarkerDrawerVsPt( filter = lambda d : d.charge() == 0 and abs(d.pdgId()) == 22, markerStyle=25, markerSizes=[1.2,1.5,1.8], ptEdges=ptEdges, markerColor=ROOT.kGreen+0 ),
+    MultiGraphMarkerDrawerVsPt( filter = lambda d : d.charge() == 0 and abs(d.pdgId()) != 22, markerStyle=25, markerSizes=[1.2,1.5,1.8], ptEdges=ptEdges, markerColor=ROOT.kBlue+0 ),
+]
+drawTkCands   = [ MultiGraphMarkerDrawerVsPt( markerStyle=27, markerSizes=[1.1,1.4,1.6], ptEdges=ptEdges, markerColor=ROOT.kViolet+1 ), ]
+drawPFCands = [
+    MultiGraphMarkerDrawerVsPt( filter = lambda d : d.charge() != 0,                          markerStyle=24, markerSizes=[1.2,1.5,1.8], ptEdges=ptEdges, markerColor=ROOT.kRed-9 ),
+    MultiGraphMarkerDrawerVsPt( filter = lambda d : d.charge() == 0 and abs(d.pdgId()) == 22, markerStyle=24, markerSizes=[1.2,1.5,1.8], ptEdges=ptEdges, markerColor=ROOT.kGreen+0 ),
+    MultiGraphMarkerDrawerVsPt( filter = lambda d : d.charge() == 0 and abs(d.pdgId()) != 22, markerStyle=24, markerSizes=[1.2,1.5,1.8], ptEdges=ptEdges, markerColor=ROOT.kBlue+0 ),
+]
+drawPuppiCands = [
+    MultiGraphMarkerDrawerVsPt( filter = lambda d : d.charge() != 0,                          markerStyle=20, markerSizes=[1.1,1.4,1.7], ptEdges=ptEdges, markerColor=ROOT.kRed-9 ),
+    MultiGraphMarkerDrawerVsPt( filter = lambda d : d.charge() == 0 and abs(d.pdgId()) == 22, markerStyle=20, markerSizes=[1.1,1.4,1.7], ptEdges=ptEdges, markerColor=ROOT.kGreen+0 ),
+    MultiGraphMarkerDrawerVsPt( filter = lambda d : d.charge() == 0 and abs(d.pdgId()) != 22, markerStyle=20, markerSizes=[1.1,1.4,1.7], ptEdges=ptEdges, markerColor=ROOT.kBlue+0 ),
+]
+
+drawPUCands = [
+    MultiGraphMarkerDrawerVsPt( filter = lambda d : d.charge() != 0,                          markerStyle=20, markerSizes=[0.8,1.0,1.2], ptEdges=ptEdges, markerColor=ROOT.kOrange-7 ),
+    MultiGraphMarkerDrawerVsPt( filter = lambda d : d.charge() == 0 and abs(d.pdgId()) == 22, markerStyle=20, markerSizes=[0.8,1.0,1.2], ptEdges=ptEdges, markerColor=ROOT.kSpring+6 ),
+    MultiGraphMarkerDrawerVsPt( filter = lambda d : d.charge() == 0 and abs(d.pdgId()) != 22, markerStyle=20, markerSizes=[0.8,1.0,1.2], ptEdges=ptEdges, markerColor=ROOT.kBlue-9 ),
+]
+

--- a/NtupleProducer/python/display/eventDisplay.py
+++ b/NtupleProducer/python/display/eventDisplay.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+import ROOT
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+ROOT.gROOT.SetBatch(True)
+ROOT.gSystem.Load("libFWCoreFWLite.so");
+ROOT.gSystem.Load("libDataFormatsFWLite.so");
+ROOT.FWLiteEnabler.enable()
+
+import os
+from sys import argv
+from math import *
+
+from DataFormats.FWLite import Handle, Events
+
+from FastPUPPI.NtupleProducer.display.drawers import *
+from FastPUPPI.NtupleProducer.display.physobjlist import *
+
+if len(argv) <= 1:
+    print """
+        usage: python eventDisplay.py file.root output_directory/    [event number]
+           or: python eventDisplay.py file.root secondaryfile.root output_directory/
+"""
+
+if ".root" in argv[2]:
+    print "Primary: %s, Secondary: %s" % (argv[1], argv[2])
+    events = Events(options=Opts(files=[argv[1]], secFiles=[argv[2]]))
+    del argv[2]
+else:
+    events = Events(argv[1])
+
+out = argv[2]
+if not os.path.isdir(out):
+    os.system("mkdir -p "+out)
+    os.system("cp index.php "+out+"/")
+
+genj  = Handle("std::vector<reco::GenJet>")
+genp  = Handle("std::vector<reco::GenParticle>")
+tracks   = Handle("std::vector<reco::Track>")
+vertices = Handle("std::vector<reco::Vertex>")
+pfcands  = Handle("std::vector<reco::PFCandidate>")
+pfclust  = Handle("std::vector<reco::PFCluster>")
+l1pfp    = Handle("std::vector<l1tpf::Particle>")
+puppiw   = Handle("edm::ValueMap<float>")
+
+for iev,event in enumerate(events):
+    if len(argv) > 3 and event.eventAuxiliary().event() != int(argv[3]): continue
+    print "\nEvent %1d %5d %12d" % (
+        event.eventAuxiliary().run(),
+        event.eventAuxiliary().luminosityBlock(),
+        event.eventAuxiliary().event())
+ 
+    phystruth = []
+    physobj  = []
+
+    genps = read(event, "genParticles", genp, filter = lambda g : g.status() == 1 and abs(g.pdgId()) not in (12,14,16))
+    phystruth.append(PhysObjList("genParticles", genps, drawGenCands, ["all"]))
+
+    vzs = [ g.vz() for g in genps ]; vzs.sort()
+    Z0 = vzs[len(vzs)/2]
+    event.getByLabel("offlinePrimaryVertices", vertices)
+    PVbest = min(vertices.product(), key = lambda pv : abs(pv.z()-Z0))
+
+    genjs = read(event, "ak4GenJetsNoNu", genj, filter = lambda g : g.pt() > 20)
+    phystruth.append(PhysObjList("genJets", genjs, drawGenJets, ["all"]))
+
+    ## === RAW L1 objects (reverse-ordered by depth)===
+    physobj.append(PhysObjList("L1HgcBH", read(event, "l1tPFHGCalBHProducerFromOfflineRechits:towers", l1pfp), drawHGCalB, ["l1","l1in"]))
+    physobj.append(PhysObjList("L1Hcal", (read(event, "l1tPFHcalProducerFromOfflineRechits:towers", l1pfp) + 
+                                          read(event, "l1tPFHFProducerFromOfflineRechits:towers", l1pfp)), drawHcal,         ["l1","l1in"]))
+    physobj.append(PhysObjList("L1HgcFH", read(event, "l1tPFHGCalFHProducerFromOfflineRechits:towers", l1pfp), drawHGCalH, ["l1","l1in"]))
+    physobj.append(PhysObjList("L1HgcEE", read(event, "l1tPFHGCalEEProducerFromOfflineRechits:towers", l1pfp), drawHGCalE, ["l1","l1in"]))
+    physobj.append(PhysObjList("L1Ecal", read(event, "l1tPFEcalProducerFromOfflineRechits:towers", l1pfp), drawEcal,       ["l1","l1in"]))
+    physobj.append(PhysObjList("L1Tk",    read(event, "l1tPFTkProducersFromOfflineTracksStrips", l1pfp), drawTracks,       ["l1","l1in"]))
+    
+    ## === CORRELATOR OUTPUTS ===
+    physobj.append(PhysObjList("L1C_Calo",  read(event, "InfoOut:Calo",  pfcands), drawCaloCands,  ["l1","l1out"]))
+    physobj.append(PhysObjList("L1C_TK",    read(event, "InfoOut:TK",    pfcands), drawTkCands,    ["l1","l1out"]))
+    physobj.append(PhysObjList("L1C_PF",    read(event, "InfoOut:PF",    pfcands), drawPFCands,    ["l1","l1out"]))
+    physobj.append(PhysObjList("L1C_Puppi", read(event, "InfoOut:Puppi", pfcands), drawPuppiCands, ["l1","l1out"]))
+
+    evname = "r%d_ls%d_ev%d"  % (event.eventAuxiliary().run(), event.eventAuxiliary().luminosityBlock(), event.eventAuxiliary().event())
+    zoomRadius = 0.4
+    for view in "l1", "l1in", "l1out":
+        cMaker.clear()
+        vlog = open(out+"/%s_%s.txt" % (evname, view), "w")
+        for p in physobj + phystruth: 
+            p.draw(view)
+            p.write(view,vlog)
+        cMaker.write(event, out+"/%s_%s.png" % (evname, view))
+        vlog.close()
+        os.system("mkdir -p "+out+"/%s_%s.dir" % (evname, view))
+        os.system("cp index.php "+out+"/%s_%s.dir/" % (evname, view))
+        for i,gj in enumerate(genjs):
+            cMaker.clear()
+            cMaker.zoom((gj.eta(), gj.phi()), zoomRadius*1.7)
+            vlog = open(out+"/%s_%s.dir/jet%d.txt" % (evname,view, i+1), "w")
+            for p in physobj + phystruth: 
+                p.draw(view)
+                p.writeZoom(view, (gj.eta(), gj.phi()), zoomRadius*1.7, zoomRadius, vlog)
+            cMaker.write(event, out+"/%s_%s.dir/jet%d.png" % (evname,view, i+1) )
+            vlog.close()
+
+
+    if len(argv) > 3: break
+    if iev >= 10: break
+

--- a/NtupleProducer/python/display/index.php
+++ b/NtupleProducer/python/display/index.php
@@ -1,0 +1,129 @@
+<html>
+<head>
+<title><?php echo getcwd(); ?></title>
+<style type='text/css'>
+body {
+    font-family: "Candara", sans-serif;
+    font-size: 9pt;
+    line-height: 10.5pt;
+}
+div.pic h3 { 
+    font-size: 11pt;
+    margin: 0.5em 1em 0.2em 1em;
+}
+div.pic p {
+    font-size: 11pt;
+    margin: 0.2em 1em 0.1em 1em;
+}
+div.pic {
+    display: block;
+    float: left;
+    background-color: white;
+    border: 1px solid #ccc;
+    padding: 2px;
+    text-align: center;
+    margin: 2px 10px 10px 2px;
+    -moz-box-shadow: 7px 5px 5px rgb(80,80,80);    /* Firefox 3.5 */
+    -webkit-box-shadow: 7px 5px 5px rgb(80,80,80); /* Chrome, Safari */
+    box-shadow: 7px 5px 5px rgb(80,80,80);         /* New browsers */  
+}
+a { text-decoration: none; color: rgb(80,0,0); }
+a:hover { text-decoration: underline; color: rgb(255,80,80); }
+div.dirlinks h2 {  margin-bottom: 4pt; margin-left: -24pt; color: rgb(80,0,0);  }
+div.dirlinks {  margin: 0 24pt; } 
+div.dirlinks a {
+    font-size: 11pt; font-weight: bold;
+    padding: 0 0.5em; 
+}
+</style>
+</head>
+<body>
+<h1><?php echo getcwd(); ?></h1>
+<?php
+$has_subs = false;
+foreach (glob("*") as $filename) {
+    if (is_dir($filename) && !preg_match("/^\..*|.*private.*/", $filename)) {
+        $has_subs = true;
+        break;
+    }
+}
+if ($has_subs) {
+    print "<div class=\"dirlinks\">\n";
+    print "<h2>Directories</h2>\n";
+    print "<a href=\"../\">[parent]</a> ";
+    foreach (glob("*") as $filename) {
+        if (is_dir($filename) && ($_SERVER['PHP_AUTH_USER'] == 'gpetrucc' || !preg_match("/^\..*|.*private.*/", $filename))) {
+            print " <a href=\"$filename\">[$filename]</a>";
+        }
+    }
+    print "</div>";
+}
+
+foreach (array("00_README.txt", "README.txt", "readme.txt") as $readme) {
+    if (file_exists($readme)) {
+        print "<pre class='readme'>\n"; readfile($readme); print "</pre>";
+    }
+}
+?>
+
+<h2><a name="plots">Plots</a></h2>
+<p><form>Filter: <input type="text" name="match" size="30" value="<?php if (isset($_GET['match'])) print htmlspecialchars($_GET['match']);  ?>" /><input type="Submit" value="Go" /><input type="checkbox"  name="regexp" <?php if ($_GET['regexp']) print "checked=\"checked\""?> >RegExp</input></form></p>
+<div>
+<?php
+$displayed = array();
+if ($_GET['noplots']) {
+    print "Plots will not be displayed.\n";
+} else {
+    $other_exts = array('.pdf', '.cxx', '.eps', '.root', '.txt', '.dir', '.info');
+    $filenames = glob("*.png"); sort($filenames);
+    foreach ($filenames as $filename) {
+        if (isset($_GET['match'])) {
+             if (isset($_GET['regexp']) && $_GET['regexp']) {
+                if (!preg_match('/.*'.$_GET['match'].'.*/', $filename)) continue;
+             } else {
+                if (!fnmatch('*'.$_GET['match'].'*', $filename)) continue;
+             }
+        }
+        array_push($displayed, $filename);
+        print "<div class='pic'>\n";
+        print "<h3><a href=\"$filename\">$filename</a></h3>";
+        print "<a href=\"$filename\"><img src=\"$filename\" style=\"border: none; width: 300px; \"></a>";
+        $others = array();
+        foreach ($other_exts as $ex) {
+            $other_filename = str_replace('.png', $ex, $filename);
+            if (file_exists($other_filename)) {
+                array_push($others, "<a class=\"file\" href=\"$other_filename\">[" . $ex . "]</a>");
+                if ($ex != '.txt') array_push($displayed, $other_filename);
+            }
+        }
+        if ($others) print "<p>Also as ".implode(', ',$others)."</p>";
+        print "</div>";
+    }
+}
+?>
+</div>
+<div style="display: block; clear:both;">
+<h2><a name="files">Other files</a></h2>
+<ul>
+<?
+foreach (glob("*") as $filename) {
+    if ($_GET['noplots'] || !in_array($filename, $displayed)) {
+        if (isset($_GET['match'])) {
+             if (isset($_GET['regexp']) && $_GET['regexp']) {
+                if (!preg_match('/.*'.$_GET['match'].'.*/', $filename)) continue;
+             } else {
+                if (!fnmatch('*'.$_GET['match'].'*', $filename)) continue;
+             }
+        }
+        if (is_dir($filename)) {
+            print "<li>[DIR] <a href=\"$filename\">$filename</a></li>";
+        } else {
+            print "<li><a href=\"$filename\">$filename</a></li>";
+        }
+    }
+}
+?>
+</ul>
+</div>
+</body>
+</html>

--- a/NtupleProducer/python/display/physobjlist.py
+++ b/NtupleProducer/python/display/physobjlist.py
@@ -1,0 +1,43 @@
+from PhysicsTools.HeppyCore.utils.deltar import *
+
+def ptsorted(x): return sorted(x, key = lambda o : -o.pt())
+def drsorted(x,center): return sorted(x, key = lambda o : deltaR(o.eta(),o.phi(),center[0],center[1]))
+
+class PhysObjList:
+    def __init__(self, name, objects, drawers=[], views=None, printer = lambda o : "", sort = ptsorted):
+        self.name = name
+        self.objects = objects
+        self.drawers = [d.clone(name) for d in drawers]
+        self.views = views
+        self.printer = printer
+        self.sort = sort
+    def draw(self,view):
+        if "all" not in self.views and view not in self.views: 
+            return
+        for mod in reversed(self.drawers): 
+            mod.draw(self.objects)
+    def write(self,view,log):
+        if "all" not in self.views and view not in self.views: 
+            return
+        log.write(self.name+"\n")
+        ptsum = 0.0
+        for o in self.sort(self.objects):
+            ptsum += o.pt()
+            log.write("      %9.3f  %+5.2f %+5.2f  %s\n" % (o.pt(), o.eta(), o.phi(), self.printer(o)))
+        log.write("  TOT %8.2f\n\n" % ptsum)
+    def writeZoom(self,view,center,size,radius,log):
+        if "all" not in self.views and view not in self.views: 
+            return
+        log.write(self.name+"\n")
+        ptsum = 0.0
+        for o in drsorted(self.objects, center):
+            if abs(o.eta()-center[0])>size or abs(o.phi()-center[1])>size: 
+                continue
+            log.write("      %9.3f  %+5.2f %+5.2f [ %+5.2f %+5.2f %.3f ] %s\n" % (o.pt(), o.eta(), o.phi(), o.eta()-center[0], o.phi()-center[1], deltaR(center[0],center[1],o.eta(),o.phi()), self.printer(o)))
+            if deltaR(center[0],center[1],o.eta(),o.phi()) < radius: 
+                ptsum += o.pt()
+        log.write("  TOT %8.2f (for a radius of %.3f)\n\n" % (ptsum,radius))
+
+def read(event,tag,handle,filter=lambda p : True):
+    event.getByLabel(tag, handle)
+    return [ p for p in handle.product() if filter(p)]

--- a/NtupleProducer/python/display/tdrstyle.cc
+++ b/NtupleProducer/python/display/tdrstyle.cc
@@ -1,0 +1,174 @@
+//
+// TDR style macro for plots in ROOT
+// .L tdrstyle.C
+// setTDRStyle()
+//
+#include <TStyle.h>
+#include <TROOT.h>
+
+// tdrGrid: Turns the grid lines on (true) or off (false)
+
+/*
+void tdrGrid(bool gridOn) {
+  tdrStyle->SetPadGridX(gridOn);
+  tdrStyle->SetPadGridY(gridOn);
+}
+*/
+
+// fixOverlay: Redraws the axis
+
+void fixOverlay() {
+  gPad->RedrawAxis();
+}
+
+void setTDRStyle(bool force) {
+//   TStyle *tdrStyle = new TStyle("tdrStyle","Style for P-TDR");
+
+// For the canvas:
+  gStyle->SetCanvasBorderMode(0);
+  gStyle->SetCanvasColor(kWhite);
+  gStyle->SetCanvasDefH(600); //Height of canvas
+  gStyle->SetCanvasDefW(600); //Width of canvas
+  gStyle->SetCanvasDefX(0);   //POsition on screen
+  gStyle->SetCanvasDefY(0);
+
+// For the Pad:
+  gStyle->SetPadBorderMode(0);
+  // gStyle->SetPadBorderSize(Width_t size = 1);
+  gStyle->SetPadColor(kWhite);
+  gStyle->SetPadGridX(false);
+  gStyle->SetPadGridY(false);
+  gStyle->SetGridColor(0);
+  gStyle->SetGridStyle(3);
+  gStyle->SetGridWidth(1);
+
+// For the frame:
+  gStyle->SetFrameBorderMode(0);
+  gStyle->SetFrameBorderSize(1);
+  gStyle->SetFrameFillColor(0);
+  gStyle->SetFrameFillStyle(0);
+  gStyle->SetFrameLineColor(1);
+  gStyle->SetFrameLineStyle(1);
+  gStyle->SetFrameLineWidth(1);
+
+// For the histo:
+  if (force) {
+      // gStyle->SetHistFillColor(1);
+      // gStyle->SetHistFillStyle(0);
+      gStyle->SetHistLineColor(1);
+      gStyle->SetHistLineStyle(0);
+      gStyle->SetHistLineWidth(1);
+      // gStyle->SetLegoInnerR(Float_t rad = 0.5);
+      // gStyle->SetNumberContours(Int_t number = 20);
+  }
+
+  gStyle->SetEndErrorSize(2);
+  //gStyle->SetErrorMarker(20);
+  gStyle->SetErrorX(0.);
+  
+  gStyle->SetMarkerStyle(20);
+
+//For the fit/function:
+  gStyle->SetOptFit(1);
+  gStyle->SetFitFormat("5.4g");
+  gStyle->SetFuncColor(2);
+  gStyle->SetFuncStyle(1);
+  gStyle->SetFuncWidth(1);
+
+//For the date:
+  gStyle->SetOptDate(0);
+  // gStyle->SetDateX(Float_t x = 0.01);
+  // gStyle->SetDateY(Float_t y = 0.01);
+
+// For the statistics box:
+  gStyle->SetOptFile(0);
+  //gStyle->SetOptStat(0);
+  gStyle->SetOptStat("mr");
+  gStyle->SetStatColor(kWhite);
+  gStyle->SetStatFont(42);
+  gStyle->SetStatFontSize(0.04);///---> gStyle->SetStatFontSize(0.025);
+  gStyle->SetStatTextColor(1);
+  gStyle->SetStatFormat("6.4g");
+  gStyle->SetStatBorderSize(1);
+  gStyle->SetStatH(0.1);
+  gStyle->SetStatW(0.2);///---> gStyle->SetStatW(0.15);
+
+  // gStyle->SetStatStyle(Style_t style = 1001);
+  // gStyle->SetStatX(Float_t x = 0);
+  // gStyle->SetStatY(Float_t y = 0);
+
+// Margins:
+  gStyle->SetPadTopMargin(0.05);
+  gStyle->SetPadBottomMargin(0.13);
+  gStyle->SetPadLeftMargin(0.16);
+  gStyle->SetPadRightMargin(0.04);
+
+// For the Global title:
+
+  gStyle->SetOptTitle(0);
+  gStyle->SetTitleFont(42);
+  gStyle->SetTitleColor(1);
+  gStyle->SetTitleTextColor(1);
+  gStyle->SetTitleFillColor(10);
+  gStyle->SetTitleFontSize(0.05);
+  // gStyle->SetTitleH(0); // Set the height of the title box
+  // gStyle->SetTitleW(0); // Set the width of the title box
+  // gStyle->SetTitleX(0); // Set the position of the title box
+  // gStyle->SetTitleY(0.985); // Set the position of the title box
+  // gStyle->SetTitleStyle(Style_t style = 1001);
+  // gStyle->SetTitleBorderSize(2);
+
+// For the axis titles:
+
+  gStyle->SetTitleColor(1, "XYZ");
+  gStyle->SetTitleFont(42, "XYZ");
+  gStyle->SetTitleSize(0.06, "XYZ");
+  // gStyle->SetTitleXSize(Float_t size = 0.02); // Another way to set the size?
+  // gStyle->SetTitleYSize(Float_t size = 0.02);
+  gStyle->SetTitleXOffset(0.9);
+  gStyle->SetTitleYOffset(1.25);
+  // gStyle->SetTitleOffset(1.1, "Y"); // Another way to set the Offset
+
+// For the axis labels:
+
+  gStyle->SetLabelColor(1, "XYZ");
+  gStyle->SetLabelFont(42, "XYZ");
+  gStyle->SetLabelOffset(0.007, "XYZ");
+  gStyle->SetLabelSize(0.05, "XYZ");
+
+// For the axis:
+
+  gStyle->SetAxisColor(1, "XYZ");
+  gStyle->SetStripDecimals(kTRUE);
+  gStyle->SetTickLength(0.03, "XYZ");
+  gStyle->SetNdivisions(510, "XYZ");
+  gStyle->SetPadTickX(1);  // To get tick marks on the opposite side of the frame
+  gStyle->SetPadTickY(1);
+
+// Change for log plots:
+  gStyle->SetOptLogx(0);
+  gStyle->SetOptLogy(0);
+  gStyle->SetOptLogz(0);
+
+// Postscript options:
+  gStyle->SetPaperSize(20.,20.);
+  // gStyle->SetLineScalePS(Float_t scale = 3);
+  // gStyle->SetLineStyleString(Int_t i, const char* text);
+  // gStyle->SetHeaderPS(const char* header);
+  // gStyle->SetTitlePS(const char* pstitle);
+
+  // gStyle->SetBarOffset(Float_t baroff = 0.5);
+  // gStyle->SetBarWidth(Float_t barwidth = 0.5);
+  // gStyle->SetPaintTextFormat(const char* format = "g");
+  // gStyle->SetPalette(Int_t ncolors = 0, Int_t* colors = 0);
+  // gStyle->SetTimeOffset(Double_t toffset);
+  // gStyle->SetHistMinimumZero(kTRUE);
+
+//   gStyle->cd();
+  gROOT->ForceStyle();
+
+}
+
+void tdrstyle(bool force=true) {
+    setTDRStyle(force);
+}

--- a/NtupleProducer/python/runNtupleProducer_cfg.py
+++ b/NtupleProducer/python/runNtupleProducer_cfg.py
@@ -47,4 +47,7 @@ process.InfoOut = cms.EDProducer('NtupleProducer',
 
 process.l1Puppi = cms.Sequence(process.l1tPFCaloProducersFromOfflineRechits+process.l1tPFTkProducersFromOfflineTracksStrips)
 process.p = cms.Path(process.l1Puppi*process.InfoOut)
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string("l1pf_out.root"),
+)
 #process.e = cms.EndPath(process.out)


### PR DESCRIPTION
Usage: recompile, turn on the output module in the cfg file, process some events, and then from `FastPUPPI/NtupleProducer/python/display` do `python eventDisplay.py rootfile output_directory`.
Example output: https://gpetrucc.web.cern.ch/gpetrucc/drop/plots/l1stage2/pre16/l1pf_test/pion_gun_pu0/