### PR TITLE
Allow running in CMSSW the same PF code as in Vivado

### DIFF
--- a/NtupleProducer/interface/BitwisePF.h
+++ b/NtupleProducer/interface/BitwisePF.h
@@ -1,0 +1,16 @@
+#ifndef FASTPUPPI_NTUPLERPRODUCER_BITWISEPF_H
+#define FASTPUPPI_NTUPLERPRODUCER_BITWISEPF_H
+
+#include "FastPUPPI/NtupleProducer/interface/DiscretePF.h"
+
+namespace l1tpf_int { 
+class BitwisePF : public PFAlgo {
+    public:
+        BitwisePF( const edm::ParameterSet& ) ;
+        virtual void runPF(Region &r) const override;
+
+  };
+
+} // end namespace
+
+#endif

--- a/NtupleProducer/interface/DiscretePF.h
+++ b/NtupleProducer/interface/DiscretePF.h
@@ -40,16 +40,14 @@ namespace l1tpf_int {
         etaCenter(0.5*(etamin+etamax)), etaMin(etamin), etaMax(etamax), phiCenter(phicenter), phiHalfWidth(0.5*phiwidth), etaExtra(etaextra), phiExtra(phiextra), relativeCoordinates(useRelativeCoordinates),
         ncaloMax(ncalomax), nemcaloMax(nemcalomax), ntrackMax(ntrackmax), nmuonMax(nmuonmax), npfMax(npfmax), npuppiMax(npuppimax) {}
 
-    unsigned int ncalo() const { return calo.size(); }
-    unsigned int nemcalo() const { return emcalo.size(); }
-    unsigned int ntrack() const { return track.size(); }
-    unsigned int nmuon() const { return muon.size(); }
-    unsigned int npf() const { return pf.size(); }
-    unsigned int npuppi() const { return puppi.size(); }
-    unsigned int npfCharged() const ; 
-    unsigned int npfNeutral() const { return npf() - npfCharged(); }
-    unsigned int npuppiCharged() const ; 
-    unsigned int npuppiNeutral() const { return npuppi() - npuppiCharged(); }
+    enum InputType { calo_type=0, emcalo_type=1, track_type=2, l1mu_type=3, n_input_types=4 };
+    static const char * inputTypeName(int inputType) ;
+
+    enum OutputType { any_type=0, charged_type=1, neutral_type=2, electron_type=3, pfmuon_type=4, charged_hadron_type=5, neutral_hadron_type=6, photon_type=7, n_output_types=8 };
+    static const char * outputTypeName(int outputType) ;
+
+    unsigned int nInput(InputType type) const ;
+    unsigned int nOutput(OutputType type, bool puppi) const ;
 
     // global coordinates
     bool contains(float eta, float phi) const { return (etaMin-etaExtra <= eta && eta <= etaMax+etaExtra && std::abs(deltaPhi(phiCenter,phi)) <= phiHalfWidth+phiExtra); }
@@ -102,6 +100,9 @@ namespace l1tpf_int {
         std::vector<l1tpf::Particle> fetch(bool puppi=true, float ptMin=0.01, bool discarded = false) const ;
         std::vector<l1tpf::Particle> fetchCalo(float ptMin=0.01, bool emcalo=false) const ;
         std::vector<l1tpf::Particle> fetchTracks(float ptMin=0.01, bool fromPV=false) const ;
+
+        std::pair<unsigned,unsigned> totAndMaxInput(/*Region::InputType*/int type) const ;
+        std::pair<unsigned,unsigned> totAndMaxOutput(/*Region::OutputType*/int type, bool puppi) const ;
     protected:
         std::vector<Region> regions_;
         bool useRelativeRegionalCoordinates_; // whether the eta,phi in each region are global or relative to the region center

--- a/NtupleProducer/interface/DiscretePF.h
+++ b/NtupleProducer/interface/DiscretePF.h
@@ -21,23 +21,17 @@ namespace edm { class ParameterSet; }
 namespace l1tpf_int { 
 
 
-  struct Region {
-    std::vector<CaloCluster>      calo;
-    std::vector<CaloCluster>      emcalo; // not used in the default implementation
-    std::vector<PropagatedTrack>  track;
-    std::vector<Muon>             muon;
+  struct Region : public InputRegion {
     std::vector<PFParticle>       pf;
     std::vector<PFParticle>       puppi;
     std::vector<PFParticle>       pfdiscarded; // for debugging
     unsigned int caloOverflow, emcaloOverflow, trackOverflow, muonOverflow, pfOverflow, puppiOverflow;
 
-    const float etaCenter, etaMin, etaMax, phiCenter, phiHalfWidth;
-    const float etaExtra, phiExtra;
     const bool relativeCoordinates; // whether the eta,phi in each region are global or relative to the region center
     const unsigned int ncaloMax, nemcaloMax, ntrackMax, nmuonMax, npfMax, npuppiMax;
     Region(float etamin, float etamax, float phicenter, float phiwidth, float etaextra, float phiextra, bool useRelativeCoordinates,
            unsigned int ncalomax, unsigned int nemcalomax, unsigned int ntrackmax, unsigned int nmuonmax, unsigned int npfmax, unsigned int npuppimax) :
-        etaCenter(0.5*(etamin+etamax)), etaMin(etamin), etaMax(etamax), phiCenter(phicenter), phiHalfWidth(0.5*phiwidth), etaExtra(etaextra), phiExtra(phiextra), relativeCoordinates(useRelativeCoordinates),
+        InputRegion(0.5*(etamin+etamax), etamin, etamax, phicenter, 0.5*phiwidth, etaextra, phiextra), relativeCoordinates(useRelativeCoordinates),
         ncaloMax(ncalomax), nemcaloMax(nemcalomax), ntrackMax(ntrackmax), nmuonMax(nmuonmax), npfMax(npfmax), npuppiMax(npuppimax) {}
 
     enum InputType { calo_type=0, emcalo_type=1, track_type=2, l1mu_type=3, n_input_types=4 };
@@ -82,7 +76,6 @@ namespace l1tpf_int {
         std::sort(puppi.begin(), puppi.end());
     }
 
-    void writeToFile(FILE *file) const ;
   };
 
   class RegionMapper {

--- a/NtupleProducer/interface/DiscretePFInputs.h
+++ b/NtupleProducer/interface/DiscretePFInputs.h
@@ -1,9 +1,20 @@
 #ifndef FASTPUPPI_NTUPLERPRODUCER_DISCRETEPFINPUTS_H
 #define FASTPUPPI_NTUPLERPRODUCER_DISCRETEPFINPUTS_H
 
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) or defined(CMSSW)
 #include <cstdint>
+#define FASTPUPPI_NTUPLERPRODUCER_DISCRETEPFINPUTS_MORE
+#else
+#include <stdint.h>
+#endif
+
+// the serialization may be hidden if needed
+#define FASTPUPPI_NTUPLERPRODUCER_DISCRETEPFINPUTS_IO
+
+#include <cassert>
 #include <cstdlib>
 #include <cmath>
+#include <vector>
 
 namespace l1tpf_int { 
 
@@ -15,12 +26,16 @@ namespace l1tpf_int {
       int16_t  hwPhi;   
       uint16_t hwFlags;
       bool     isEM, used;
+
+      // sorting
+      bool operator<(const CaloCluster &other) const { return hwPt > other.hwPt; }
+
+#ifdef FASTPUPPI_NTUPLERPRODUCER_DISCRETEPFINPUTS_MORE
       static constexpr float PT_SCALE = 4.0;     // quantize in units of 0.25 GeV (can be changed)
       static constexpr float ETAPHI_FACTOR = 4;  // size of an ecal crystal in phi in integer units (our choice)
       static constexpr float ETAPHI_SCALE = ETAPHI_FACTOR*(180./M_PI);  // M_PI/180 is the size of an ECal crystal; we make a grid that is 4 times that size
       static constexpr int16_t PHI_WRAP = 360*ETAPHI_FACTOR;            // what is 3.14 in integer
-      // sorting
-      bool operator<(const CaloCluster &other) const { return hwPt > other.hwPt; }
+
       // filling from floating point
       void fill(float pt, float emPt, float ptErr, float eta, float phi, bool em, unsigned int flags) {
           hwPt  = round(pt  * CaloCluster::PT_SCALE);
@@ -32,6 +47,7 @@ namespace l1tpf_int {
           used = false;
           hwFlags = flags;
       }
+
       float floatPt() const { return float(hwPt) / CaloCluster::PT_SCALE; }
       float floatEmPt() const { return float(hwEmPt) / CaloCluster::PT_SCALE; }
       float floatPtErr() const { return float(hwPtErr) / CaloCluster::PT_SCALE; }
@@ -40,6 +56,30 @@ namespace l1tpf_int {
       float floatPhi() const { return float(hwPhi) / CaloCluster::ETAPHI_SCALE; }
       void  setFloatPt(float pt) { hwPt  = round(pt  * CaloCluster::PT_SCALE); }
       void  setFloatEmPt(float emPt) { hwEmPt  = round(emPt  * CaloCluster::PT_SCALE); }
+#endif
+
+#ifdef FASTPUPPI_NTUPLERPRODUCER_DISCRETEPFINPUTS_IO
+      void writeToFile(FILE *file) const {
+        fwrite(&hwPt, 2, 1, file);
+        fwrite(&hwEmPt, 2, 1, file);
+        fwrite(&hwPtErr, 2, 1, file);
+        fwrite(&hwEta, 2, 1, file);
+        fwrite(&hwPhi, 2, 1, file);
+        fwrite(&hwFlags, 2, 1, file);
+        fwrite(&isEM, 1, 1, file); 
+        // used is not written out
+      }
+      void readFromFile(FILE *file) {
+        fread(&hwPt, 2, 1, file);
+        fread(&hwEmPt, 2, 1, file);
+        fread(&hwPtErr, 2, 1, file);
+        fread(&hwEta, 2, 1, file);
+        fread(&hwPhi, 2, 1, file);
+        fread(&hwFlags, 2, 1, file);
+        fread(&isEM, 1, 1, file); 
+        used = false;
+      }
+#endif
   };
 
   // https://twiki.cern.ch/twiki/bin/view/CMS/L1TriggerPhase2InterfaceSpecifications
@@ -51,11 +91,14 @@ namespace l1tpf_int {
       int16_t  hwZ0;
       uint16_t hwChi2, hwStubs;
       uint16_t hwFlags;
+
+#ifdef FASTPUPPI_NTUPLERPRODUCER_DISCRETEPFINPUTS_MORE
       static constexpr float INVPT_SCALE   = 2E4;    // 1%/pt @ 100 GeV is 2 bits 
       static constexpr float VTX_PHI_SCALE = 1/2.5E-6; // 5 micro rad is 2 bits
       static constexpr float VTX_ETA_SCALE = 1/1E-5;   // no idea, but assume it's somewhat worse than phi
       static constexpr float Z0_SCALE      = 20;     // 1mm is 2 bits
       static constexpr int32_t VTX_ETA_1p3 = 1.3 * InputTrack::VTX_ETA_SCALE;
+
       // filling from floating point
       void fillInput(float pt, float eta, float phi, int charge, float dz, unsigned int flags) {
           hwInvpt  = round(1/pt  * InputTrack::INVPT_SCALE);
@@ -65,11 +108,36 @@ namespace l1tpf_int {
           hwZ0     = round(dz  * InputTrack::Z0_SCALE);
           hwFlags = flags;
       }
+
       float floatVtxPt() const { return 1/(float(hwInvpt) / InputTrack::INVPT_SCALE); }
       float floatVtxEta() const { return float(hwVtxEta) / InputTrack::VTX_ETA_SCALE; }
       float floatVtxPhi() const { return float(hwVtxPhi) / InputTrack::VTX_PHI_SCALE; }
       float floatDZ()     const { return float(hwZ0) / InputTrack::Z0_SCALE; }
       int intCharge()     const { return hwCharge ? +1 : -1; }
+#endif
+
+#ifdef FASTPUPPI_NTUPLERPRODUCER_DISCRETEPFINPUTS_IO
+      void writeToFile(FILE *file) const {
+        fwrite(&hwInvpt, 2, 1, file);
+        fwrite(&hwVtxEta, 4, 1, file);
+        fwrite(&hwVtxPhi, 4, 1, file);
+        fwrite(&hwCharge, 1, 1, file); 
+        fwrite(&hwZ0, 2, 1, file);
+        fwrite(&hwChi2, 2, 1, file);
+        fwrite(&hwStubs, 2, 1, file);
+        fwrite(&hwFlags, 2, 1, file);
+      }
+      void readFromFile(FILE *file) {
+        fread(&hwInvpt, 2, 1, file);
+        fread(&hwVtxEta, 4, 1, file);
+        fread(&hwVtxPhi, 4, 1, file);
+        fread(&hwCharge, 1, 1, file); 
+        fread(&hwZ0, 2, 1, file);
+        fread(&hwChi2, 2, 1, file);
+        fread(&hwStubs, 2, 1, file);
+        fread(&hwFlags, 2, 1, file);
+      }
+#endif
   };
 
   struct PropagatedTrack : public InputTrack {
@@ -81,8 +149,11 @@ namespace l1tpf_int {
       bool     muonLink;
       bool     used; // note: this flag is not used in the default PF, but is used in alternative algos
       bool     fromPV;
+
       // sorting
       bool operator<(const PropagatedTrack &other) const { return hwPt > other.hwPt; }
+
+#ifdef FASTPUPPI_NTUPLERPRODUCER_DISCRETEPFINPUTS_MORE
       void fillPropagated(float pt, float ptErr, float caloPtErr, float eta, float phi, unsigned int flags) {
           hwPt  = round(pt  * CaloCluster::PT_SCALE);
           hwPtErr = round(ptErr  * CaloCluster::PT_SCALE);
@@ -92,21 +163,49 @@ namespace l1tpf_int {
           muonLink = false;
           used = false;
       }
+
       float floatPt() const { return float(hwPt) / CaloCluster::PT_SCALE; }
       float floatPtErr() const { return float(hwPtErr) / CaloCluster::PT_SCALE; }
       float floatCaloPtErr() const { return float(hwCaloPtErr) / CaloCluster::PT_SCALE; }
       float floatEta() const { return float(hwEta) / CaloCluster::ETAPHI_SCALE; }
       float floatPhi() const { return float(hwPhi) / CaloCluster::ETAPHI_SCALE; }
+#endif
+
+#ifdef FASTPUPPI_NTUPLERPRODUCER_DISCRETEPFINPUTS_IO
+      void writeToFile(FILE *file) const {
+        InputTrack::writeToFile(file);
+        fwrite(&hwPt, 2, 1, file);
+        fwrite(&hwPtErr, 2, 1, file);
+        fwrite(&hwCaloPtErr, 2, 1, file);
+        fwrite(&hwEta, 2, 1, file);
+        fwrite(&hwPhi, 2, 1, file);
+        // muonLink, used, fromPV are transient
+      }
+      void readFromFile(FILE *file) {
+        InputTrack::readFromFile(file);
+        fread(&hwPt, 2, 1, file);
+        fread(&hwPtErr, 2, 1, file);
+        fread(&hwCaloPtErr, 2, 1, file);
+        fread(&hwEta, 2, 1, file);
+        fread(&hwPhi, 2, 1, file);
+        muonLink = false; used = false; fromPV = false;
+      }
+#endif
+
+
   };
 
   struct Muon {
-      int16_t hwPt;   
+      int16_t  hwPt;   
       int16_t  hwEta;   // at calo
       int16_t  hwPhi;   // at calo
       uint16_t hwFlags;
       bool     hwCharge;
+
       // sorting
       bool operator<(const Muon &other) const { return hwPt > other.hwPt; }
+
+#ifdef FASTPUPPI_NTUPLERPRODUCER_DISCRETEPFINPUTS_MORE
       void fill(float pt, float eta, float phi, int charge, unsigned int flags) {
           // we assume we use the same discrete ieta, iphi grid for all particles 
           hwPt  = round(pt  * CaloCluster::PT_SCALE);
@@ -119,6 +218,24 @@ namespace l1tpf_int {
       float floatEta() const { return float(hwEta) / CaloCluster::ETAPHI_SCALE; }
       float floatPhi() const { return float(hwPhi) / CaloCluster::ETAPHI_SCALE; }
       int intCharge()     const { return hwCharge ? +1 : -1; }
+#endif
+
+#ifdef FASTPUPPI_NTUPLERPRODUCER_DISCRETEPFINPUTS_IO
+      void writeToFile(FILE *file) const {
+        fwrite(&hwPt, 2, 1, file);
+        fwrite(&hwEta, 2, 1, file);
+        fwrite(&hwPhi, 2, 1, file);
+        fwrite(&hwFlags, 2, 1, file);
+        fwrite(&hwCharge, 1, 1, file); 
+      }
+      void readFromFile(FILE *file) {
+        fread(&hwPt, 2, 1, file);
+        fread(&hwEta, 2, 1, file);
+        fread(&hwPhi, 2, 1, file);
+        fread(&hwFlags, 2, 1, file);
+        fread(&hwCharge, 1, 1, file); 
+      }
+#endif
   };
 
   struct PFParticle {
@@ -134,9 +251,13 @@ namespace l1tpf_int {
       bool            chargedPV;
       uint16_t        hwPuppiWeight;
       uint16_t        hwStatus; // for debugging
-      static constexpr float PUPPI_SCALE = 100;
+
       // sorting
       bool operator<(const PFParticle &other) const { return hwPt > other.hwPt; }
+
+#ifdef FASTPUPPI_NTUPLERPRODUCER_DISCRETEPFINPUTS_MORE
+      static constexpr float PUPPI_SCALE = 100;
+
       float floatPt() const { return float(hwPt) / CaloCluster::PT_SCALE; }
       float floatEta() const { return float(hwEta) / CaloCluster::ETAPHI_SCALE; }
       float floatPhi() const { return float(hwPhi) / CaloCluster::ETAPHI_SCALE; }
@@ -149,6 +270,70 @@ namespace l1tpf_int {
             hwPuppiWeight = std::round(w * PUPPI_SCALE);
       }
       void  setFloatPt(float pt) { hwPt  = round(pt  * CaloCluster::PT_SCALE); }
+#endif
+  };
+
+
+#ifdef FASTPUPPI_NTUPLERPRODUCER_DISCRETEPFINPUTS_IO
+  template<typename T>
+  void writeManyToFile(const std::vector<T> & objs, FILE *file) {
+    uint32_t number = objs.size(); 
+    fwrite(&number, 4, 1, file);
+    for (uint32_t i = 0; i < number; ++i) objs[i].writeToFile(file);
+  }
+
+  template<typename T>
+  void readManyFromFile(std::vector<T> & objs, FILE *file) {
+    uint32_t number;
+    fread(&number, 4, 1, file);
+    objs.resize(number); 
+    for (uint32_t i = 0; i < number; ++i) objs[i].readFromFile(file);
+  }
+#endif
+
+  struct InputRegion {
+    float etaCenter, etaMin, etaMax, phiCenter, phiHalfWidth;
+    float etaExtra, phiExtra;
+    std::vector<CaloCluster>      calo;
+    std::vector<CaloCluster>      emcalo;
+    std::vector<PropagatedTrack>  track;
+    std::vector<Muon>             muon;
+
+    InputRegion() : etaCenter(), etaMin(), etaMax(), phiCenter(), phiHalfWidth(), etaExtra(), phiExtra() {}
+    InputRegion(float etacenter, float etamin, float etamax, float phicenter, float phihalfwidth, float etaextra, float phiextra) :
+        etaCenter(etacenter), etaMin(etamin), etaMax(etamax), phiCenter(phicenter), phiHalfWidth(phihalfwidth), etaExtra(etaextra), phiExtra(phiextra) {}
+
+#ifdef FASTPUPPI_NTUPLERPRODUCER_DISCRETEPFINPUTS_IO
+    void writeToFile(FILE *file) const {
+        assert(4 == sizeof(float));
+        fwrite(&etaCenter, 4, 1, file);
+        fwrite(&etaMin,    4, 1, file);
+        fwrite(&etaMax,    4, 1, file);
+        fwrite(&phiCenter, 4, 1, file);
+        fwrite(&phiHalfWidth, 4, 1, file);
+        fwrite(&etaExtra, 4, 1, file);
+        fwrite(&phiExtra, 4, 1, file);
+        writeManyToFile(calo, file);
+        writeManyToFile(emcalo, file);
+        writeManyToFile(track, file);
+        writeManyToFile(muon, file);
+    }
+    void readFromFile(FILE *file) {
+        assert(4 == sizeof(float));
+        fread(&etaCenter, 4, 1, file);
+        fread(&etaMin,    4, 1, file);
+        fread(&etaMax,    4, 1, file);
+        fread(&phiCenter, 4, 1, file);
+        fread(&phiHalfWidth, 4, 1, file);
+        fread(&etaExtra, 4, 1, file);
+        fread(&phiExtra, 4, 1, file);
+        readManyFromFile(calo, file);
+        readManyFromFile(emcalo, file);
+        readManyFromFile(track, file);
+        readManyFromFile(muon, file);
+    }
+#endif
+    
   };
 
 } // namespace

--- a/NtupleProducer/plugins/JetNTuplizer.cc
+++ b/NtupleProducer/plugins/JetNTuplizer.cc
@@ -69,20 +69,24 @@ class JetNTuplizer : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
         std::string name;
         int   count_raw, count_corr;
         float ht_raw, ht_corr;
+        float mht_raw, mht_corr;
         JetBranch(const std::string &n) : name(n) {}
         void makeBranches(TTree *tree) {
             tree->Branch((name+"_ht_raw").c_str(),   &ht_raw,   (name+"_ht_raw/F").c_str());
+            tree->Branch((name+"_mht_raw").c_str(),   &mht_raw,   (name+"_mht_raw/F").c_str());
             tree->Branch((name+"_num_raw").c_str(), &count_raw, (name+"_num_raw/I").c_str());
             tree->Branch((name+"_ht_corr").c_str(),   &ht_corr,   (name+"_ht_corr/F").c_str());
+            tree->Branch((name+"_mht_corr").c_str(),   &mht_corr,   (name+"_mht_corr/F").c_str());
             tree->Branch((name+"_num_corr").c_str(), &count_corr, (name+"_num_corr/I").c_str());
         }
         void fill(const edm::View<reco::Jet> & jets, const  l1tpf::SimpleCorrEm & corr, const StringCutObjectSelector<reco::Jet> & sel) {  
             count_raw = 0; ht_raw = 0;
             count_corr = 0; ht_corr = 0;
+            reco::Particle::LorentzVector sum_raw, sum_corr;
             for (reco::Jet jet : jets) {
-                if (sel(jet)) { count_raw++; ht_raw += std::min(jet.pt(),500.); }
+                if (sel(jet)) { count_raw++; ht_raw += std::min(jet.pt(),500.); sum_raw += jet.p4(); }
                 jet.setP4(reco::Particle::PolarLorentzVector(corr(jet.pt(), std::abs(jet.eta())), jet.eta(), jet.phi(), jet.mass()));
-                if (sel(jet)) { count_corr++; ht_corr += std::min(jet.pt(),500.); }
+                if (sel(jet)) { count_corr++; ht_corr += std::min(jet.pt(),500.); sum_corr += jet.p4(); }
             }
         }
       };

--- a/NtupleProducer/plugins/NtupleProducer.cc
+++ b/NtupleProducer/plugins/NtupleProducer.cc
@@ -396,9 +396,7 @@ NtupleProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     fwrite(&run, sizeof(uint32_t), 1, fRegionDump);
     fwrite(&lumi, sizeof(uint32_t), 1, fRegionDump);
     fwrite(&event, sizeof(uint64_t), 1, fRegionDump);
-    uint32_t nregions = l1regions_.regions().size();
-    fwrite(&nregions, sizeof(uint32_t), 1, fRegionDump);
-    for (const auto & r : l1regions_.regions()) r.writeToFile(fRegionDump);
+    l1tpf_int::writeManyToFile(l1regions_.regions(), fRegionDump);
   } 
 
 

--- a/NtupleProducer/plugins/NtupleProducer.cc
+++ b/NtupleProducer/plugins/NtupleProducer.cc
@@ -239,26 +239,15 @@ NtupleProducer::NtupleProducer(const edm::ParameterSet& iConfig):
     TokEmClusterTags_.push_back(consumes<L1PFCollection>(tag));
   }
   TokMuonTPTag_    = consumes<L1PFCollection>( MuonTPTag_  );
-  produces<unsigned int>("totNL1TK");
-  produces<unsigned int>("totNL1Mu");
-  produces<unsigned int>("totNL1Calo");
-  produces<unsigned int>("totNL1EmCalo");
-  produces<unsigned int>("totNL1PF");
-  produces<unsigned int>("totNL1PFCharged");
-  produces<unsigned int>("totNL1PFNeutral");
-  produces<unsigned int>("totNL1Puppi");
-  produces<unsigned int>("totNL1PuppiCharged");
-  produces<unsigned int>("totNL1PuppiNeutral");
-  produces<unsigned int>("maxNL1TK");
-  produces<unsigned int>("maxNL1Mu");
-  produces<unsigned int>("maxNL1Calo");
-  produces<unsigned int>("maxNL1EmCalo");
-  produces<unsigned int>("maxNL1PF");
-  produces<unsigned int>("maxNL1PFCharged");
-  produces<unsigned int>("maxNL1PFNeutral");
-  produces<unsigned int>("maxNL1Puppi");
-  produces<unsigned int>("maxNL1PuppiCharged");
-  produces<unsigned int>("maxNL1PuppiNeutral");
+  for (int tot = 0; tot <= 1; ++tot) {
+      for (int i = 0; i < l1tpf_int::Region::n_input_types; ++i) {
+          produces<unsigned int>(std::string(tot ? "totNL1" : "maxNL1")+l1tpf_int::Region::inputTypeName(i));
+      }
+      for (int i = 0; i < l1tpf_int::Region::n_output_types; ++i) {
+          produces<unsigned int>(std::string(tot ? "totNL1PF"    : "maxNL1PF"   )+l1tpf_int::Region::outputTypeName(i));
+          produces<unsigned int>(std::string(tot ? "totNL1Puppi" : "maxNL1Puppi")+l1tpf_int::Region::outputTypeName(i));
+      }
+  }
 }
 
 NtupleProducer::~NtupleProducer()
@@ -458,41 +447,20 @@ NtupleProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   produces<PFOutputCollection>("PFDiscarded");
 
   // then go do the multiplicities
-  unsigned int totNL1Calo = 0, totNL1EmCalo = 0, totNL1TK = 0, totNL1Mu = 0, totNL1PF = 0, totNL1PFCharged = 0, totNL1PFNeutral = 0, totNL1Puppi = 0, totNL1PuppiCharged = 0, totNL1PuppiNeutral = 0;
-  unsigned int maxNL1Calo = 0, maxNL1EmCalo = 0, maxNL1TK = 0, maxNL1Mu = 0, maxNL1PF = 0, maxNL1PFCharged = 0, maxNL1PFNeutral = 0, maxNL1Puppi = 0, maxNL1PuppiCharged = 0, maxNL1PuppiNeutral = 0;
-  for (const auto & r : l1regions_.regions()) {
-      if (std::abs(r.etaCenter) > 1.5) continue;
-      totNL1Calo += r.ncalo();
-      totNL1EmCalo += r.nemcalo();
-      totNL1TK += r.ntrack();
-      totNL1PF += r.npf();
-      totNL1Mu += r.nmuon();
-      totNL1Puppi += r.npuppi();
-      totNL1PFCharged += r.npfCharged();
-      totNL1PuppiCharged += r.npuppiCharged();
-      totNL1PFNeutral += r.npfNeutral();
-      totNL1PuppiNeutral += r.npuppiNeutral();
-      maxNL1Calo = std::max<unsigned>( maxNL1Calo, r.ncalo() );
-      maxNL1EmCalo = std::max<unsigned>( maxNL1EmCalo, r.nemcalo() );
-      maxNL1TK = std::max<unsigned>( maxNL1TK, r.ntrack() );
-      maxNL1PF = std::max<unsigned>( maxNL1PF, r.npf() );
-      maxNL1Mu = std::max<unsigned>( maxNL1Mu, r.nmuon() );
-      maxNL1Puppi = std::max<unsigned>( maxNL1Puppi, r.npuppi() );
-      maxNL1PFCharged = std::max<unsigned>( maxNL1PFCharged, r.npfCharged() );
-      maxNL1PuppiCharged = std::max<unsigned>( maxNL1PuppiCharged, r.npuppiCharged() );
-      maxNL1PFNeutral = std::max<unsigned>( maxNL1PFNeutral, r.npfNeutral() );
-      maxNL1PuppiNeutral = std::max<unsigned>( maxNL1PuppiNeutral, r.npuppiNeutral() );
+  for (int i = 0; i < l1tpf_int::Region::n_input_types; ++i) {
+      auto totAndMax = l1regions_.totAndMaxInput(i);
+      addUInt(totAndMax.first,  std::string("totNL1")+l1tpf_int::Region::inputTypeName(i), iEvent);
+      addUInt(totAndMax.second, std::string("maxNL1")+l1tpf_int::Region::inputTypeName(i), iEvent);
   }
-  addUInt(totNL1Calo, "totNL1Calo", iEvent); addUInt(maxNL1Calo, "maxNL1Calo", iEvent);
-  addUInt(totNL1EmCalo, "totNL1EmCalo", iEvent); addUInt(maxNL1EmCalo, "maxNL1EmCalo", iEvent);
-  addUInt(totNL1TK, "totNL1TK", iEvent); addUInt(maxNL1TK, "maxNL1TK", iEvent);
-  addUInt(totNL1Mu, "totNL1Mu", iEvent); addUInt(maxNL1Mu, "maxNL1Mu", iEvent);
-  addUInt(totNL1PF, "totNL1PF", iEvent); addUInt(maxNL1PF, "maxNL1PF", iEvent);
-  addUInt(totNL1Puppi, "totNL1Puppi", iEvent); addUInt(maxNL1Puppi, "maxNL1Puppi", iEvent);
-  addUInt(totNL1PFCharged, "totNL1PFCharged", iEvent); addUInt(maxNL1PFCharged, "maxNL1PFCharged", iEvent);
-  addUInt(totNL1PuppiCharged, "totNL1PuppiCharged", iEvent); addUInt(maxNL1PuppiCharged, "maxNL1PuppiCharged", iEvent);
-  addUInt(totNL1PFNeutral, "totNL1PFNeutral", iEvent); addUInt(maxNL1PFNeutral, "maxNL1PFNeutral", iEvent);
-  addUInt(totNL1PuppiNeutral, "totNL1PuppiNeutral", iEvent); addUInt(maxNL1PuppiNeutral, "maxNL1PuppiNeutral", iEvent);
+  for (int i = 0; i < l1tpf_int::Region::n_output_types; ++i) {
+      auto totAndMaxPF = l1regions_.totAndMaxOutput(i,false);
+      auto totAndMaxPuppi = l1regions_.totAndMaxOutput(i,true);
+      addUInt(totAndMaxPF.first,  std::string("totNL1PF")+l1tpf_int::Region::outputTypeName(i), iEvent);
+      addUInt(totAndMaxPF.second, std::string("maxNL1PF")+l1tpf_int::Region::outputTypeName(i), iEvent);
+      addUInt(totAndMaxPuppi.first,  std::string("totNL1Puppi")+l1tpf_int::Region::outputTypeName(i), iEvent);
+      addUInt(totAndMaxPuppi.second, std::string("maxNL1Puppi")+l1tpf_int::Region::outputTypeName(i), iEvent);
+  }
+
  
   if (metanalyzer_) {
       metanalyzer_->clear();

--- a/NtupleProducer/plugins/NtupleProducer.cc
+++ b/NtupleProducer/plugins/NtupleProducer.cc
@@ -43,6 +43,7 @@
 #include "FastPUPPI/NtupleProducer/interface/SimpleCalibrations.h"
 #include "FastPUPPI/NtupleProducer/interface/DiscretePF.h"
 #include "FastPUPPI/NtupleProducer/interface/AlternativePF.h"
+#include "FastPUPPI/NtupleProducer/interface/BitwisePF.h"
 
 #include "DataFormats/Math/interface/deltaR.h"
 
@@ -203,6 +204,8 @@ NtupleProducer::NtupleProducer(const edm::ParameterSet& iConfig):
       l1pfalgo_.reset(new l1tpf_int::PFAlgo3(iConfig));
   } else if (algo == "PFAlgoOld") {
       l1pfalgo_.reset(new l1tpf_int::PFAlgo(iConfig));
+  } else if (algo == "BitwisePF") {
+      l1pfalgo_.reset(new l1tpf_int::BitwisePF(iConfig));
   } else throw cms::Exception("Configuration", "Unsupported PFAlgo");
 
   std::string regionDumpFile = iConfig.getUntrackedParameter<std::string>("regionDumpFileName", "");

--- a/NtupleProducer/python/runRespNTupler.py
+++ b/NtupleProducer/python/runRespNTupler.py
@@ -50,11 +50,13 @@ process.ntuple = cms.EDAnalyzer("ResponseNTuplizer",
         L1PF = cms.VInputTag("InfoOut:PF",),
         L1Puppi = cms.VInputTag("InfoOut:Puppi",),
     ),
-    copyUInts = cms.VInputTag(
-        "InfoOut:totNL1Calo", "InfoOut:totNL1EmCalo", "InfoOut:totNL1TK", "InfoOut:totNL1Mu", "InfoOut:totNL1PF", "InfoOut:totNL1PFCharged", "InfoOut:totNL1PFNeutral", "InfoOut:totNL1Puppi", "InfoOut:totNL1PuppiCharged", "InfoOut:totNL1PuppiNeutral",
-        "InfoOut:maxNL1Calo", "InfoOut:maxNL1EmCalo", "InfoOut:maxNL1TK", "InfoOut:maxNL1Mu", "InfoOut:maxNL1PF", "InfoOut:maxNL1PFCharged", "InfoOut:maxNL1PFNeutral", "InfoOut:maxNL1Puppi", "InfoOut:maxNL1PuppiCharged", "InfoOut:maxNL1PuppiNeutral",
-    )
+    copyUInts = cms.VInputTag(),
 )
+for X in "tot","max":
+    for I in "Calo EmCalo TK Mu".split(): process.ntuple.copyUInts.append( "InfoOut:%sNL1%s" % (X,I))
+    for O in [""] + "Charged Neutral ChargedHadron NeutralHadron Photon Electron Muon".split():
+        process.ntuple.copyUInts.append( "InfoOut:%sNL1PF%s" % (X,O))
+        process.ntuple.copyUInts.append( "InfoOut:%sNL1Puppi%s" % (X,O))
 process.p = cms.Path(process.l1tPFHGCalProducerFrom3DTPsEM + process.CaloInfoOut + process.InfoOut + process.ntuple)
 process.TFileService = cms.Service("TFileService", fileName = cms.string("respTupleNew.root"))
 

--- a/NtupleProducer/python/runRespNTupler.py
+++ b/NtupleProducer/python/runRespNTupler.py
@@ -145,11 +145,16 @@ if False:
     process.source.fileNames = ['file:/eos/cms/store/cmst3/user/gpetrucc/l1phase2/Spring17D/200517/inputs_17D_TTbar_PU0_job1.root' ]
     process.p.remove(process.ntuple)
     process.TFileService.fileName = cms.string("trackTupleNew.root")
+if False: # run bitwise PF for Vivado
+    goRegional()
+    process.InfoOut.useRelativeRegionalCoordinates = cms.bool(True)
+    process.InfoOut.linking.algo = "BitwisePF"
+    process.source.fileNames = ['file:/eos/cms/store/cmst3/user/jngadiub/L1PFInputs/SinglePion_PU0/inputs_17D_SinglePion_PU0_job1.root', ]
 if False: # prepare dump file for Vivado
     goRegional()
     process.InfoOut.useRelativeRegionalCoordinates = cms.bool(True)
     process.InfoOut.regionDumpFileName = cms.untracked.string("regions_TTbar_PU140.dump")
-    process.source.fileNames = ['file:/eos/cms/store/cmst3/user/gpetrucc/l1phase2/Spring17D/200517/inputs_17D_TTbar_PU140_job10.root']
+    process.source.fileNames = ['file:/eos/cms/store/cmst3/user/jngadiub/L1PFInputs/TTbar_PU140/inputs_17D_TTbar_PU140_job1.root'] #, 'file:/eos/cms/store/cmst3/user/jngadiub/L1PFInputs/TTbar_PU140/inputs_17D_TTbar_PU140_job2.root', 'file:/eos/cms/store/cmst3/user/jngadiub/L1PFInputs/TTbar_PU140/inputs_17D_TTbar_PU140_job3.root', 'file:/eos/cms/store/cmst3/user/jngadiub/L1PFInputs/TTbar_PU140/inputs_17D_TTbar_PU140_job4.root', 'file:/eos/cms/store/cmst3/user/jngadiub/L1PFInputs/TTbar_PU140/inputs_17D_TTbar_PU140_job5.root', 'file:/eos/cms/store/cmst3/user/jngadiub/L1PFInputs/TTbar_PU140/inputs_17D_TTbar_PU140_job6.root', ]
      
 if False:
     #process.CaloInfoOutBackup = process.CaloInfoOut.clone()

--- a/NtupleProducer/python/scripts/objMultiplicityPlot.py
+++ b/NtupleProducer/python/scripts/objMultiplicityPlot.py
@@ -11,6 +11,7 @@ from math import *
 
 from optparse import OptionParser
 parser = OptionParser("%(prog) infile [ src [ dst ] ]")
+parser.add_option("--cl", type=float, dest="cl", default=0, help="Compute number to avoid truncations at this CL")
 options, args = parser.parse_args()
 
 odir = args[1] # "plots/910pre2/test"
@@ -18,17 +19,30 @@ os.system("mkdir -p "+odir)
 os.system("cp %s/src/FastPUPPI/NtupleProducer/python/display/index.php %s/" % (os.environ['CMSSW_BASE'], odir));
 ROOT.gROOT.ProcessLine(".x %s/src/FastPUPPI/NtupleProducer/python/display/tdrstyle.cc" % os.environ['CMSSW_BASE']);
 c1 = ROOT.TCanvas("c1","c1")
-particles = {
-    "Calo":(10000,200),  "EmCalo":(10000,200), "Mu":(100,100), "TK":(1000,1000), "PF":(1000,1000), "PFCharged":(1000,1000), "PFNeutral":(1000,1000), "Puppi":(1000,1000), "PuppiCharged":(1000,1000), "PuppiNeutral":(1000,1000)
-}.items()
+particles = [ "Calo", "EmCalo", "Mu", "TK" ]
+for Algo in "PF", "Puppi":
+    particles.append(Algo)
+    for Type in "Charged Neutral ChargedHadron NeutralHadron Photon Electron Muon".split():
+        particles.append(Algo+Type)
 tfile = ROOT.TFile.Open(args[0])
 tree = tfile.Get("ntuple/tree")
 ROOT.gStyle.SetOptStat("omr")
-for particle, (nmax, nmaxtot) in particles:
-    for x,bins in ("tot",nmaxtot),("max",nmax):
-        print "%sNL1%s" % (x, particle)
-        n = tree.Draw("%sNL1%s" % (x, particle), "mc_id == 998", "")
+for particle in particles:
+    if options.cl > 0:
+        n = tree.Draw("min(maxNL1%s,199)>>htemp(200,-0.5,199.5)" % (particle), "mc_id == 998", "")
         if not n: continue
-        out = odir+'/'+particle+"_"+x+".png"
-        c1.Print(out)
+        h = ROOT.gROOT.FindObject("htemp")
+        acc = 0
+        for b in xrange(0,h.GetNbinsX()+2):
+            acc += h.GetBinContent(b)
+            if acc > n * options.cl: 
+                print "%-20s %3.0f" % (particle, h.GetBinCenter(b))
+                break
+    else:
+        for x in "tot","max":
+            print "%sNL1%s" % (x, particle)
+            n = tree.Draw("%sNL1%s" % (x, particle), "mc_id == 998", "")
+            if not n: continue
+            out = odir+'/'+particle+"_"+x+".png"
+            c1.Print(out)
 

--- a/NtupleProducer/src/BitwisePF.cc
+++ b/NtupleProducer/src/BitwisePF.cc
@@ -1,0 +1,68 @@
+#include "../interface/BitwisePF.h"
+#include "firmware/simple_fullpfalgo.h"
+#include "DiscretePF2Firmware.h"
+#include "Firmware2DiscretePF.h"
+
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+int dr2_int(etaphi_t eta1, etaphi_t phi1, etaphi_t eta2, etaphi_t phi2) {
+    etaphi_t deta = (eta1-eta2);
+    etaphi_t dphi = (phi1-phi2);
+    return deta*deta + dphi*dphi;
+}
+
+using namespace l1tpf_int;
+
+BitwisePF::BitwisePF( const edm::ParameterSet & iConfig ) :
+    PFAlgo(iConfig)
+{
+    debug_ = iConfig.getUntrackedParameter<int>("bitwiseDebug", debug_);
+}
+
+void BitwisePF::runPF(Region &r) const {
+    initRegion(r);
+
+    if (debug_) {
+        printf("ALT \t region Eta [ %+5.2f , %+5.2f ],  Phi [ %+5.2f , %+5.2f ] \n", r.etaMin, r.etaMax, r.phiCenter-r.phiHalfWidth, r.phiCenter+r.phiHalfWidth );
+        printf("ALT \t N(track) %3lu   N(em) %3lu   N(calo) %3lu\n", r.track.size(), r.emcalo.size(), r.calo.size());
+        for (int itk = 0, ntk = r.track.size(); itk < ntk; ++itk) {
+            const auto & tk = r.track[itk]; 
+            printf("ALT \t track %3d: pt %7.2f +- %5.2f  vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f calo ptErr %7.2f stubs %2d chi2 %7.1f\n", 
+                                itk, tk.floatPt(), tk.floatPtErr(), tk.floatVtxEta(), tk.floatVtxPhi(), tk.floatEta(), tk.floatPhi(), tk.floatCaloPtErr(), int(tk.hwStubs), tk.hwChi2*0.1f);
+        }
+        for (int iem = 0, nem = r.emcalo.size(); iem < nem; ++iem) {
+            const auto & em = r.emcalo[iem];
+            printf("ALT \t EM    %3d: pt %7.2f +- %5.2f  vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f calo ptErr %7.2f\n", 
+                                iem, em.floatPt(), em.floatPtErr(), em.floatEta(), em.floatPhi(), em.floatEta(), em.floatPhi(), em.floatPtErr());
+        } 
+        for (int ic = 0, nc = r.calo.size(); ic < nc; ++ic) {
+            auto & calo = r.calo[ic]; 
+            printf("ALT \t calo  %3d: pt %7.2f +- %5.2f  vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f calo ptErr %7.2f em pt %7.2f \n", 
+                                ic, calo.floatPt(), calo.floatPtErr(), calo.floatEta(), calo.floatPhi(), calo.floatEta(), calo.floatPhi(), calo.floatPtErr(), calo.floatEmPt());
+        }
+    }
+
+    EmCaloObj emcalo[NEMCALO];
+    HadCaloObj hadcalo[NCALO];
+    TkObj track[NTRACK];
+    MuObj mu[NMU];
+    PFChargedObj outch[NTRACK];
+    PFNeutralObj outpho[NPHOTON];
+    PFNeutralObj outne[NSELCALO];
+    PFChargedObj outmu[NMU];
+
+    dpf2fw::convert<NTRACK>(r.track, track);
+    dpf2fw::convert<NCALO>(r.calo, hadcalo);
+    dpf2fw::convert<NEMCALO>(r.emcalo, emcalo);
+    dpf2fw::convert<NMU>(r.muon, mu);
+
+    pfalgo3_full_ref(emcalo, hadcalo, track, mu, outch, outpho, outne, outmu);
+
+    r.pf.clear();
+    fw2dpf::convert<NTRACK>(outch, r.track, r.pf); // FIXME works only with a 1-1 mapping
+    fw2dpf::convert<NSELCALO>(outne, r.pf);
+    fw2dpf::convert<NPHOTON>(outpho, r.pf);
+    // muons and electrons are already included in outch
+}
+

--- a/NtupleProducer/src/DiscretePF.cc
+++ b/NtupleProducer/src/DiscretePF.cc
@@ -81,22 +81,22 @@ void Region::writeToFile(FILE *file) const {
     number = calo.size(); size = sizeof(CaloCluster);
     fwrite(&number, sizeof(uint32_t), 1, file);
     fwrite(&size,   sizeof(uint32_t), 1, file);
-    fwrite(&calo[0], size, number, file);
+    for (unsigned int j = 0; j < number; ++j) fwrite(&calo[j], size, 1, file);
 
     number = emcalo.size(); size = sizeof(CaloCluster);
     fwrite(&number, sizeof(uint32_t), 1, file);
     fwrite(&size,   sizeof(uint32_t), 1, file);
-    fwrite(&emcalo[0], size, number, file);
+    for (unsigned int j = 0; j < number; ++j) fwrite(&emcalo[j], size, 1, file);
 
     number = track.size(); size = sizeof(PropagatedTrack);
     fwrite(&number, sizeof(uint32_t), 1, file);
     fwrite(&size,   sizeof(uint32_t), 1, file);
-    fwrite(&track[0], size, number, file);
+    for (unsigned int j = 0; j < number; ++j) fwrite(&track[j], size, 1, file);
 
     number = muon.size(); size = sizeof(Muon);
     fwrite(&number, sizeof(uint32_t), 1, file);
     fwrite(&size,   sizeof(uint32_t), 1, file);
-    fwrite(&muon[0], size, number, file);
+    for (unsigned int j = 0; j < number; ++j) fwrite(&muon[j], size, 1, file);
 }
 
 RegionMapper::RegionMapper( const edm::ParameterSet& iConfig )  :

--- a/NtupleProducer/src/DiscretePF.cc
+++ b/NtupleProducer/src/DiscretePF.cc
@@ -68,37 +68,6 @@ unsigned int Region::nOutput(OutputType type, bool usePuppi) const {
     return ret;
 }
 
-void Region::writeToFile(FILE *file) const {
-    fwrite(&etaCenter, sizeof(float), 1, file);
-    fwrite(&etaMin,    sizeof(float), 1, file);
-    fwrite(&etaMax,    sizeof(float), 1, file);
-    fwrite(&phiCenter, sizeof(float), 1, file);
-    fwrite(&phiHalfWidth, sizeof(float), 1, file);
-    fwrite(&etaExtra, sizeof(float), 1, file);
-    fwrite(&phiExtra, sizeof(float), 1, file);
-
-    uint32_t number; uint32_t size;
-    number = calo.size(); size = sizeof(CaloCluster);
-    fwrite(&number, sizeof(uint32_t), 1, file);
-    fwrite(&size,   sizeof(uint32_t), 1, file);
-    for (unsigned int j = 0; j < number; ++j) fwrite(&calo[j], size, 1, file);
-
-    number = emcalo.size(); size = sizeof(CaloCluster);
-    fwrite(&number, sizeof(uint32_t), 1, file);
-    fwrite(&size,   sizeof(uint32_t), 1, file);
-    for (unsigned int j = 0; j < number; ++j) fwrite(&emcalo[j], size, 1, file);
-
-    number = track.size(); size = sizeof(PropagatedTrack);
-    fwrite(&number, sizeof(uint32_t), 1, file);
-    fwrite(&size,   sizeof(uint32_t), 1, file);
-    for (unsigned int j = 0; j < number; ++j) fwrite(&track[j], size, 1, file);
-
-    number = muon.size(); size = sizeof(Muon);
-    fwrite(&number, sizeof(uint32_t), 1, file);
-    fwrite(&size,   sizeof(uint32_t), 1, file);
-    for (unsigned int j = 0; j < number; ++j) fwrite(&muon[j], size, 1, file);
-}
-
 RegionMapper::RegionMapper( const edm::ParameterSet& iConfig )  :
     useRelativeRegionalCoordinates_(false)
 {

--- a/NtupleProducer/src/DiscretePF2Firmware.h
+++ b/NtupleProducer/src/DiscretePF2Firmware.h
@@ -1,0 +1,49 @@
+#ifndef FASTPUPPI_NTUPLERPRODUCER_DISCRETEPF2FIRMWARE_H
+#define FASTPUPPI_NTUPLERPRODUCER_DISCRETEPF2FIRMWARE_H
+
+/// NOTE: this include is not standalone, since the path to DiscretePFInputs is different in CMSSW & Vivado_HLS
+
+#include "firmware/data.h"
+#include <vector>
+
+namespace dpf2fw {
+
+    // convert inputs from discrete to firmware
+    void convert(const l1tpf_int::PropagatedTrack & in, TkObj &out) {
+        out.hwPt = in.hwPt;
+        out.hwPtErr = in.hwCaloPtErr;
+        out.hwEta = in.hwEta; // @calo
+        out.hwPhi = in.hwPhi; // @calo
+        out.hwZ0 = in.hwZ0;
+    }
+    void convert(const l1tpf_int::CaloCluster & in, HadCaloObj & out) {
+        out.hwPt = in.hwPt;
+        out.hwEmPt = in.hwEmPt;
+        out.hwEta = in.hwEta;
+        out.hwPhi = in.hwPhi;
+        out.hwIsEM = in.isEM;
+    }
+    void convert(const l1tpf_int::CaloCluster & in, EmCaloObj & out) {
+        out.hwPt = in.hwPt;
+        out.hwPtErr = in.hwPtErr;
+        out.hwEta = in.hwEta;
+        out.hwPhi = in.hwPhi;
+    }
+    void convert(const l1tpf_int::Muon & in, MuObj & out) {
+        out.hwPt = in.hwPt;
+        out.hwPtErr = 0; // does not exist in input
+        out.hwEta = in.hwEta; // @calo
+        out.hwPhi = in.hwPhi; // @calo
+    }
+
+    template<unsigned int NMAX, typename In, typename Out>
+    void convert(const std::vector<In> & in, Out out[NMAX]) {
+        for (unsigned int i = 0, n = std::min<unsigned int>(NMAX, in.size()); i < n; ++i) {
+            convert(in[i], out[i]);
+        }
+    }
+
+
+} // namespace
+
+#endif

--- a/NtupleProducer/src/Firmware2DiscretePF.h
+++ b/NtupleProducer/src/Firmware2DiscretePF.h
@@ -1,0 +1,65 @@
+#ifndef FASTPUPPI_NTUPLERPRODUCER_FIRMWARE2DISCRETEPF_H
+#define FASTPUPPI_NTUPLERPRODUCER_FIRMWARE2DISCRETEPF_H
+
+/// NOTE: this include is not standalone, since the path to DiscretePFInputs is different in CMSSW & Vivado_HLS
+
+#include "firmware/data.h"
+#include <vector>
+#include <cassert>
+
+namespace fw2dpf {
+
+    // convert inputs from discrete to firmware
+    void convert(const PFChargedObj & src, const l1tpf_int::PropagatedTrack & track, std::vector<l1tpf_int::PFParticle> &out) {
+        l1tpf_int::PFParticle pf;
+        pf.hwPt = src.hwPt;
+        pf.hwEta = src.hwEta;
+        pf.hwPhi = src.hwPhi;
+        pf.hwVtxEta = src.hwEta; // FIXME: get from the track
+        pf.hwVtxPhi = src.hwPhi; // before propagation
+        pf.track = track; // FIXME: ok only as long as there is a 1-1 mapping
+        pf.cluster.hwPt = 0;
+        switch(src.hwId) {
+            case PID_Electron: pf.hwId =  l1tpf::Particle::EL; break;
+            case PID_Muon: pf.hwId =  l1tpf::Particle::MU; break;
+            default: pf.hwId =  l1tpf::Particle::CH; break;
+        };
+        pf.hwStatus = 0;
+        out.push_back(pf);
+    }
+    void convert(const PFNeutralObj & src, std::vector<l1tpf_int::PFParticle> &out) {
+        l1tpf_int::PFParticle pf;
+        pf.hwPt = src.hwPt;
+        pf.hwEta = src.hwEta;
+        pf.hwPhi = src.hwPhi;
+        pf.hwVtxEta = src.hwEta;
+        pf.hwVtxPhi = src.hwPhi;
+        pf.track.hwPt = 0;
+        pf.cluster.hwPt = src.hwPt;
+        switch(src.hwId) {
+            case PID_Photon: pf.hwId = l1tpf::Particle::GAMMA; break;
+            default: pf.hwId = l1tpf::Particle::NH; break;
+        }
+        pf.hwStatus = 0;
+        out.push_back(pf);
+    }
+
+    template<unsigned int NMAX, typename In>
+    void convert(const In in[NMAX], std::vector<l1tpf_int::PFParticle> &out) {
+        for (unsigned int i = 0; i < NMAX; ++i) {
+            if (in[i].hwPt > 0) convert(in[i], out);
+        }
+    } 
+    template<unsigned int NMAX>
+    void convert(const PFChargedObj in[NMAX], std::vector<l1tpf_int::PropagatedTrack> srctracks, std::vector<l1tpf_int::PFParticle> &out) {
+        for (unsigned int i = 0; i < NMAX; ++i) {
+            if (in[i].hwPt > 0) {
+                assert(i < srctracks.size());
+                convert(in[i], srctracks[i], out);
+            }
+        }
+    }
+
+} // namespace
+
+#endif

--- a/NtupleProducer/src/firmware/ap_int.h
+++ b/NtupleProducer/src/firmware/ap_int.h
@@ -1,0 +1,81 @@
+template<typename T>
+class bitref_ {
+    public:
+        bitref_(T & number, const int nbit) : num_(number), bit_(nbit) {}
+        operator bool() const { return (num_ & (1 << bit_)); }
+        bitref_ & operator=(bool value) {
+            if (value) num_ |=  (1 << bit_);
+            else       num_ &= ~(1 << bit_); 
+            return *this;
+        }
+    private:
+        T & num_;
+        const int bit_;
+};
+
+template<unsigned int N, typename T=int> class ap_int {
+    public:
+        typedef T base_type;
+
+        ap_int(T value=0) : value_(mask(value)) { /*printf("ap_int<%u>(%d) = { value_ = %d; }\n", N, value, value_);*/ }
+
+        template<unsigned int M> 
+        ap_int(const ap_int<M,T> & other) { value_ = mask(other.value_); }
+
+        operator T() const { return value_; }
+
+        static T mask(T value) { return (value >= 0 ? value & pos_mask() : value | neg_mask()); }
+        static T pos_mask() { return (1 << (N-1))-1; }
+        static T neg_mask() { return    ~pos_mask(); }
+
+        ap_int<N,T> & operator+=(int i) { value_ = mask(value_ + i); return *this; }
+        ap_int<N,T> & operator-=(int i) { value_ = mask(value_ - i); return *this; }
+
+        bool operator[](int i) const { return value_ & (1 << i); }
+        bitref_<T> operator[](int i) { return bitref_<T>(value_, i); }
+
+        ap_int<N,T> operator<<(int i) const { return ap_int<N,T>(value_ << i); }
+        ap_int<N,T> operator>>(int i) const { return ap_int<N,T>(value_ >> i); }
+    private:
+        T value_;
+};
+
+template<unsigned int N, unsigned int M, typename T>
+inline int operator+ (const ap_int<N,T> & a, const ap_int<M,T> &b ) { return T(a)+T(b); }
+template<unsigned int N, unsigned int M, typename T>
+inline int operator- (const ap_int<N,T> & a, const ap_int<M,T> &b ) { return T(a)-T(b); }
+template<unsigned int N, unsigned int M, typename T>
+inline int operator* (const ap_int<N,T> & a, const ap_int<M,T> &b ) { return T(a)*T(b); }
+
+template<unsigned int N, typename T=unsigned> class ap_uint {
+    public:
+        typedef T base_type;
+
+        ap_uint(const T &value=0) : value_(value & mask()) {}
+
+        template<unsigned int M>
+        ap_uint(const ap_uint<M,T> & other) { value_ = (other & mask()); }
+
+        operator T() const { return value_; }
+
+        static T mask() { return (1 << N)-1; }
+
+        ap_uint<N,T> & operator+=(unsigned i) { value_ = mask() & (value_ + i); return *this;  }
+        ap_uint<N,T> & operator-=(unsigned i) { value_ = mask() & (value_ - i); return *this;  }
+
+        bool operator[](int i) const { return value_ & (1 << i); }
+        bitref_<T> operator[](int i) { return bitref_<T>(value_, i); }
+
+        ap_uint<N,T> operator<<(int i) const { return ap_uint<N,T>(value_ << i); }
+        ap_uint<N,T> operator>>(int i) const { return ap_uint<N,T>(value_ >> i); }
+    private:
+        T value_;
+};
+
+template<unsigned int N, unsigned int M, typename T>
+inline int operator+ (const ap_uint<N,T> & a, const ap_uint<M,T> &b ) { return T(a)+T(b); }
+template<unsigned int N, unsigned int M, typename T>
+inline int operator- (const ap_uint<N,T> & a, const ap_uint<M,T> &b ) { return T(a)-T(b); }
+template<unsigned int N, unsigned int M, typename T>
+inline int operator* (const ap_uint<N,T> & a, const ap_uint<M,T> &b ) { return T(a)*T(b); }
+

--- a/NtupleProducer/src/firmware/data.h
+++ b/NtupleProducer/src/firmware/data.h
@@ -1,0 +1,84 @@
+#ifndef SIMPLE_PFLOW_DATA_H
+#define SIMPLE_PFLOW_DATA_H
+
+#include "ap_int.h"
+
+typedef ap_int<16> pt_t;
+typedef ap_int<9>  etaphi_t;
+typedef ap_int<5>  vtx_t;
+typedef ap_uint<3>  particleid_t;
+typedef ap_int<10> z0_t;  // 40cm / 0.1
+		
+enum PID { PID_Charged=0, PID_Neutral=1, PID_Photon=2, PID_Electron=3, PID_Muon=4 };
+
+// VERTEXING
+#define NVTXBINS  15
+#define NPOW 6
+#define NALLTRACK 1 << NPOW
+#define NSECTOR 1
+#define VTXPTMAX  200
+
+// PF
+#ifdef TESTMP7  // reduced input size to fit in a board
+   #define NTRACK 7
+   #define NCALO 5
+   #define NMU 2
+   #define NEMCALO 5
+   #define NPHOTON NEMCALO
+   #define NSELCALO 4
+#else
+   #define NTRACK 15
+   #define NCALO 15
+   #define NMU 4
+   #define NEMCALO 15
+   #define NPHOTON NEMCALO
+   #define NSELCALO 10
+#endif
+
+// PUPPI & CHS
+#define NPVTRACK 7
+
+
+struct CaloObj {
+	pt_t hwPt;
+	etaphi_t hwEta, hwPhi; // relative to the region center, at calo
+};
+struct HadCaloObj : public CaloObj {
+	pt_t hwEmPt;
+   	bool hwIsEM;
+};
+struct EmCaloObj {
+	pt_t hwPt, hwPtErr;
+	etaphi_t hwEta, hwPhi; // relative to the region center, at calo
+};
+struct TkObj {
+	pt_t hwPt, hwPtErr;
+	etaphi_t hwEta, hwPhi; // relative to the region center, at calo
+	z0_t hwZ0;
+};
+struct MuObj {
+	pt_t hwPt, hwPtErr;
+	etaphi_t hwEta, hwPhi; // relative to the region center, at vtx(?)
+};
+struct PFChargedObj {
+	pt_t hwPt;
+	etaphi_t hwEta, hwPhi; // relative to the region center, at calo
+	particleid_t hwId;
+	z0_t hwZ0;
+};
+struct PFNeutralObj {
+	pt_t hwPt;
+	etaphi_t hwEta, hwPhi; // relative to the region center, at calo
+	particleid_t hwId;
+};
+struct VtxObj {
+	pt_t  hwSumPt;
+	z0_t  hwZ0;
+	vtx_t mult;
+	particleid_t hwId;
+};
+
+#define MP7_NCHANN 72
+typedef ap_uint<32> MP7DataWord;
+
+#endif

--- a/NtupleProducer/src/firmware/simple_fullpfalgo.h
+++ b/NtupleProducer/src/firmware/simple_fullpfalgo.h
@@ -1,0 +1,25 @@
+#ifndef SIMPLE_PFALGO3_H
+#define SIMPLE_PFALGO3_H
+
+#include "data.h"
+
+bool match_box(etaphi_t eta1, etaphi_t phi1, etaphi_t eta2, etaphi_t phi2, etaphi_t boxSize) ;
+etaphi_t dr_box(etaphi_t eta1, etaphi_t phi1, etaphi_t eta2, etaphi_t phi2) ;
+int dr2_int(etaphi_t eta1, etaphi_t phi1, etaphi_t eta2, etaphi_t phi2) ;
+template<int NB> ap_uint<NB>  dr2_int_cap(etaphi_t eta1, etaphi_t phi1, etaphi_t eta2, etaphi_t phi2, ap_uint<NB> max) ;
+
+void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], MuObj mu[NMU], PFChargedObj outch[NTRACK], PFNeutralObj outpho[NPHOTON], PFNeutralObj outne[NSELCALO], PFChargedObj outmu[NMU]) ;
+void pfalgo3_full(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], MuObj mu[NMU], PFChargedObj outch[NTRACK], PFNeutralObj outpho[NPHOTON], PFNeutralObj outne[NSELCALO], PFChargedObj outmu[NMU]) ;
+void mp7wrapped_pack_in(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], MuObj mu[NMU], MP7DataWord data[MP7_NCHANN]) ;
+void mp7wrapped_unpack_in(MP7DataWord data[MP7_NCHANN], EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], MuObj mu[NMU]) ;
+void mp7wrapped_pack_out(PFChargedObj outch[NTRACK], PFNeutralObj outpho[NPHOTON], PFNeutralObj outne[NSELCALO], PFChargedObj outmu[NMU], MP7DataWord data[MP7_NCHANN]) ;
+void mp7wrapped_unpack_out(MP7DataWord data[MP7_NCHANN], PFChargedObj outch[NTRACK], PFNeutralObj outpho[NPHOTON], PFNeutralObj outne[NSELCALO], PFChargedObj outmu[NMU]) ;
+void mp7wrapped_pfalgo3_full(MP7DataWord input[MP7_NCHANN], MP7DataWord output[MP7_NCHANN]) ;
+
+#define PFALGO3_DR2MAX_TK_CALO 756
+#define PFALGO3_DR2MAX_EM_CALO 525
+#define PFALGO3_DR2MAX_TK_MU   2101
+#define PFALGO3_DR2MAX_TK_EM   84
+#define PFALGO3_TK_MAXINVPT    80
+
+#endif

--- a/NtupleProducer/src/simple_fullpfalgo_ref.cpp
+++ b/NtupleProducer/src/simple_fullpfalgo_ref.cpp
@@ -1,0 +1,350 @@
+#include "firmware/data.h"
+#include "firmware/simple_fullpfalgo.h"
+#include <cmath>
+#include <algorithm>
+
+template <typename T> int sqr(const T & t) { return t*t; }
+
+template<int NCAL, int DR2MAX, bool doPtMin, typename CO_t>
+int best_match_ref(CO_t calo[NCAL], const TkObj & track) {
+    pt_t caloPtMin = track.hwPt - 2*(track.hwPtErr);
+    if (caloPtMin < 0) caloPtMin = 0;
+    int  drmin = DR2MAX, ibest = -1;
+    for (int ic = 0; ic < NCAL; ++ic) {
+            if (doPtMin && calo[ic].hwPt <= caloPtMin) continue;
+            int dr = dr2_int(track.hwEta, track.hwPhi, calo[ic].hwEta, calo[ic].hwPhi);
+            if (dr < drmin) { drmin = dr; ibest = ic; }
+    }
+    return ibest;
+}
+template<int NCAL, int DR2MAX>
+int best_match_ref(HadCaloObj calo[NCAL], const EmCaloObj & em) {
+    pt_t emPtMin = em.hwPt >> 1;
+    int  drmin = DR2MAX, ibest = -1;
+    for (int ic = 0; ic < NCAL; ++ic) {
+            if (calo[ic].hwEmPt <= emPtMin) continue;
+            int dr = dr2_int(em.hwEta, em.hwPhi, calo[ic].hwEta, calo[ic].hwPhi);
+            if (dr < drmin) { drmin = dr; ibest = ic; }
+    }
+    return ibest;
+}
+
+template<int NCAL, int DR2MAX, typename CO_t>
+int best_match_with_pt_ref(CO_t calo[NCAL], const TkObj & track) {
+    pt_t caloPtMin = track.hwPt - 2*(track.hwPtErr);
+    if (caloPtMin < 0) caloPtMin = 0;
+    int dptscale = (DR2MAX<<8)/std::max<int>(1,sqr(track.hwPtErr));
+    int drmin = 0, ibest = -1;
+    for (int ic = 0; ic < NCAL; ++ic) {
+            if (calo[ic].hwPt <= caloPtMin) continue;
+            int dr = dr2_int(track.hwEta, track.hwPhi, calo[ic].hwEta, calo[ic].hwPhi);
+            if (dr >= DR2MAX) continue;
+            dr += (( sqr(std::max<int>(track.hwPt-calo[ic].hwPt,0))*dptscale ) >> 8);
+            //printf("REF DQ(track %+7d %+7d  calo %3d) = %12d\n", int(track.hwEta), int(track.hwPhi), ic, dr);
+            if (ibest == -1 || dr < drmin) { drmin = dr; ibest = ic; }
+    }
+    return ibest;
+}
+
+
+template<int NCAL, int DR2MAX, bool doPtMin, typename CO_t>
+void link_ref(CO_t calo[NCAL], TkObj track[NTRACK], ap_uint<NCAL> calo_track_link_bit[NTRACK]) {
+    for (int it = 0; it < NTRACK; ++it) {
+        int ibest = best_match_ref<NCALO,DR2MAX,doPtMin,CO_t>(calo, track[it]);
+        calo_track_link_bit[it] = 0;
+        if (ibest != -1) calo_track_link_bit[it][ibest] = 1;
+    }
+}
+
+template<typename T, int NIn, int NOut>
+void ptsort_ref(T in[NIn], T out[NOut]) {
+    for (int iout = 0; iout < NOut; ++iout) {
+        out[iout].hwPt = 0;
+    }
+    for (int it = 0; it < NIn; ++it) {
+        for (int iout = 0; iout < NOut; ++iout) {
+            if (in[it].hwPt >= out[iout].hwPt) {
+                for (int i2 = NOut-1; i2 > iout; --i2) {
+                    out[i2] = out[i2-1];
+                }
+                out[iout] = in[it];
+                break;
+            }
+        }
+    }
+}
+
+
+void pfalgo3_calo_ref(HadCaloObj calo[NCALO], TkObj track[NTRACK], PFChargedObj outch[NTRACK], PFNeutralObj outne[NCALO]) {
+    // constants
+    const pt_t     TKPT_MAX = PFALGO3_TK_MAXINVPT; // 20 * PT_SCALE;
+    const int      DR2MAX   = PFALGO3_DR2MAX_TK_CALO;
+
+    // initialize sum track pt
+    pt_t calo_sumtk[NCALO], calo_subpt[NCALO];
+    int  calo_sumtkErr2[NCALO];
+    for (int ic = 0; ic < NCALO; ++ic) { calo_sumtk[ic] = 0;  calo_sumtkErr2[ic] = 0;}
+
+    // initialize good track bit
+    bool track_good[NTRACK];
+    for (int it = 0; it < NTRACK; ++it) { track_good[it] = (track[it].hwPt < TKPT_MAX); }
+
+    // initialize output
+    for (int ipf = 0; ipf < NTRACK; ++ipf) { outch[ipf].hwPt = 0; }
+    for (int ipf = 0; ipf < NSELCALO; ++ipf) { outne[ipf].hwPt = 0; }
+
+    // for each track, find the closest calo
+    for (int it = 0; it < NTRACK; ++it) {
+        if (track[it].hwPt > 0) {
+            //int  ibest = best_match_ref<NCALO,DR2MAX,true,HadCaloObj>(calo, track[it]);
+            int  ibest = best_match_with_pt_ref<NCALO,DR2MAX,HadCaloObj>(calo, track[it]);
+            if (ibest != -1) {
+                track_good[it] = 1;
+                calo_sumtk[ibest]    += track[it].hwPt;
+                calo_sumtkErr2[ibest] += sqr(track[it].hwPtErr);
+            }
+        }
+    }
+
+    for (int ic = 0; ic < NCALO; ++ic) {
+        if (calo_sumtk[ic] > 0) {
+            pt_t ptdiff = calo[ic].hwPt - calo_sumtk[ic];
+            if (ptdiff > 0 && ptdiff*ptdiff > 4*calo_sumtkErr2[ic]) {
+                calo_subpt[ic] = ptdiff;
+            } else {
+                calo_subpt[ic] = 0;
+            }
+        } else {
+            calo_subpt[ic] = calo[ic].hwPt;
+        }
+    }
+
+    // copy out charged hadrons
+    for (int it = 0; it < NTRACK; ++it) {
+        if (track_good[it]) {
+            outch[it].hwPt = track[it].hwPt;
+            outch[it].hwEta = track[it].hwEta;
+            outch[it].hwPhi = track[it].hwPhi;
+            outch[it].hwZ0 = track[it].hwZ0;
+            outch[it].hwId  = PID_Charged;
+        }
+    }
+
+    // copy out neutral hadrons
+    PFNeutralObj outne_all[NCALO];
+    for (int ipf = 0; ipf < NCALO; ++ipf) { outne_all[ipf].hwPt = 0; }
+    for (int ic = 0; ic < NCALO; ++ic) {
+        if (calo_subpt[ic] > 0) {
+            outne_all[ic].hwPt  = calo_subpt[ic];
+            outne_all[ic].hwEta = calo[ic].hwEta;
+            outne_all[ic].hwPhi = calo[ic].hwPhi;
+            outne_all[ic].hwId  = PID_Neutral;
+        }
+    }
+
+    ptsort_ref<PFNeutralObj,NCALO,NSELCALO>(outne_all, outne);
+}
+
+void pfalgo3_em_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], bool isEle[NTRACK], bool isMu[NTRACK], PFNeutralObj outpho[NPHOTON], HadCaloObj hadcalo_out[NCALO]) {
+    // constants
+    const int DR2MAX_TE = PFALGO3_DR2MAX_TK_EM;
+    const int DR2MAX_EH = PFALGO3_DR2MAX_EM_CALO;
+
+    // initialize sum track pt
+    pt_t calo_sumtk[NEMCALO];
+    for (int ic = 0; ic < NEMCALO; ++ic) {  calo_sumtk[ic] = 0; }
+    int tk2em[NTRACK]; 
+    bool isEM[NEMCALO];
+    // for each track, find the closest calo
+    for (int it = 0; it < NTRACK; ++it) {
+        if (track[it].hwPt > 0 && !isMu[it]) {
+            tk2em[it] = best_match_ref<NEMCALO,DR2MAX_TE,false,EmCaloObj>(emcalo, track[it]);
+            // printf("C++: tk not 0 index = %i and matched calo index = %i \n", it, int(tk2em[it]) );
+            if (tk2em[it] != -1) {
+                calo_sumtk[tk2em[it]] += track[it].hwPt;
+            }
+        } else {
+        	tk2em[it] = -1;
+        }
+        // printf("C++: tk index = %i and match = %i and sumtk = %i \n", it, int(tk2em[it]), int(calo_sumtk[tk2em[it]]));        
+    }
+
+    // for (int ic = 0; ic < NEMCALO; ++ic) {  printf("C++: calo_sumtk[NEMCALO] = %i \n", int(calo_sumtk[ic])); }
+
+    for (int ic = 0; ic < NEMCALO; ++ic) {
+        pt_t photonPt;
+        if (calo_sumtk[ic] > 0) {
+            pt_t ptdiff = emcalo[ic].hwPt - calo_sumtk[ic];
+            if (ptdiff*ptdiff <= 4*sqr(emcalo[ic].hwPtErr)) {
+                // electron
+                photonPt = 0; 
+                isEM[ic] = true;
+            } else if (ptdiff > 0) {
+                // electron + photon
+                photonPt = ptdiff; 
+                isEM[ic] = true;
+            } else {
+                // pion
+                photonPt = 0;
+                isEM[ic] = false;
+            }
+        } else {
+            // photon
+            isEM[ic] = true;
+            photonPt = emcalo[ic].hwPt;
+        }
+        outpho[ic].hwPt  = photonPt;
+        outpho[ic].hwEta = photonPt ? emcalo[ic].hwEta : etaphi_t(0);
+        outpho[ic].hwPhi = photonPt ? emcalo[ic].hwPhi : etaphi_t(0);
+        outpho[ic].hwId  = photonPt ? PID_Photon : particleid_t(0);
+
+        // printf("C++: emcalo index = %i and pt = %i and calo_sumtk = %i \n", ic, int(photonPt),int(calo_sumtk[ic]));
+    }
+
+    for (int it = 0; it < NTRACK; ++it) {
+        isEle[it] = (tk2em[it] != -1) && isEM[tk2em[it]];
+    }
+
+    int em2calo[NEMCALO];
+    for (int ic = 0; ic < NEMCALO; ++ic) {
+        em2calo[ic] = best_match_ref<NCALO,DR2MAX_EH>(hadcalo, emcalo[ic]);
+    }
+    
+    for (int ih = 0; ih < NCALO; ++ih) {
+        hadcalo_out[ih] = hadcalo[ih];
+        pt_t sub = 0;
+        for (int ic = 0; ic < NEMCALO; ++ic) {
+            if (isEM[ic] && (em2calo[ic] == ih)) {
+                sub += emcalo[ic].hwPt;
+            }
+        }
+        pt_t emdiff  = hadcalo[ih].hwEmPt - sub;
+        pt_t alldiff = hadcalo[ih].hwPt - sub;
+        if (alldiff < ( hadcalo[ih].hwPt >>  4 ) ) {
+            hadcalo_out[ih].hwPt = 0;   // kill
+            hadcalo_out[ih].hwEmPt = 0; // kill
+        } else if (hadcalo[ih].hwIsEM && emdiff < ( hadcalo[ih].hwEmPt >> 3 ) ) {
+            hadcalo_out[ih].hwPt = 0;   // kill
+            hadcalo_out[ih].hwEmPt = 0; // kill
+        } else {
+            hadcalo_out[ih].hwPt   = alldiff;   
+            hadcalo_out[ih].hwEmPt = (emdiff > 0 ? emdiff : pt_t(0)); 
+        }
+    }
+}
+
+void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], MuObj mu[NMU], PFChargedObj outch[NTRACK], PFNeutralObj outpho[NPHOTON], PFNeutralObj outne[NSELCALO], PFChargedObj outmu[NMU]) {
+
+    // constants
+    const pt_t     TKPT_MAX = PFALGO3_TK_MAXINVPT; // 20 * PT_SCALE;
+    const int      DR2MAX   = PFALGO3_DR2MAX_TK_CALO;
+    const int      DR2MAX_TM = PFALGO3_DR2MAX_TK_MU;
+
+    ////////////////////////////////////////////////////
+    // TK-MU Linking
+
+    // initialize good track bit
+    // bool mu_good[NMU];
+    // for (int im = 0; im < NMU; ++im) { mu_good[im] = (mu[im].hwPt < TKPT_MAX); }
+
+    // initialize output
+    for (int ipf = 0; ipf < NMU; ++ipf) { outmu[ipf].hwPt = 0; outmu[ipf].hwEta = 0; outmu[ipf].hwPhi = 0; outmu[ipf].hwId  = 0; outmu[ipf].hwZ0  = 0; }
+
+    bool isMu[NTRACK];
+    for (int it = 0; it < NTRACK; ++it) { isMu[it] = 0; } // initialize
+    // for each muon, find the closest track
+    for (int im = 0; im < NMU; ++im) {
+        if (mu[im].hwPt > 0) {
+            pt_t tkPtMin = mu[im].hwPt - 2*(mu[im].hwPtErr);
+            int  drmin = DR2MAX_TM, ibest = -1;
+            for (int it = 0; it < NTRACK; ++it) {
+                if (track[it].hwPt <= tkPtMin) continue;
+                int dr = dr2_int(mu[im].hwEta, mu[im].hwPhi, track[it].hwEta, track[it].hwPhi);
+                //printf("deltaR2(mu %d float pt %5.1f, tk %2d float pt %5.1f) = int %d  (float deltaR = %.3f); int cut at %d\n", im, 0.25*int(mu[im].hwPt), it, 0.25*int(track[it].hwPt), dr, std::sqrt(float(dr))/229.2, PFALGO3_DR2MAX_TK_MU);
+                if (dr < drmin) { drmin = dr; ibest = it; }
+            }
+            if (ibest != -1) {
+                outmu[im].hwPt = track[ibest].hwPt;
+                outmu[im].hwEta = track[ibest].hwEta;
+                outmu[im].hwPhi = track[ibest].hwPhi;
+                outmu[im].hwId  = PID_Muon;
+                outmu[im].hwZ0 = track[ibest].hwZ0;      
+                isMu[ibest] = 1;
+            }
+        }
+    }
+
+    ////////////////////////////////////////////////////
+    // TK-EM Linking
+    bool isEle[NTRACK];
+    HadCaloObj hadcalo_subem[NCALO];
+    pfalgo3_em_ref(emcalo, hadcalo, track, isEle, isMu, outpho, hadcalo_subem);
+
+    ////////////////////////////////////////////////////
+    // TK-HAD Linking
+
+    // initialize sum track pt
+    pt_t calo_sumtk[NCALO], calo_subpt[NCALO];
+    int  calo_sumtkErr2[NCALO];
+    for (int ic = 0; ic < NCALO; ++ic) { calo_sumtk[ic] = 0;  calo_sumtkErr2[ic] = 0;}
+
+    // initialize good track bit
+    bool track_good[NTRACK];
+    for (int it = 0; it < NTRACK; ++it) { track_good[it] = (track[it].hwPt < TKPT_MAX || isEle[it] || isMu[it]); }
+
+    // initialize output
+    for (int ipf = 0; ipf < NTRACK; ++ipf) { outch[ipf].hwPt = 0; outch[ipf].hwEta = 0; outch[ipf].hwPhi = 0; outch[ipf].hwId = 0; outch[ipf].hwZ0 = 0; }
+    for (int ipf = 0; ipf < NSELCALO; ++ipf) { outne[ipf].hwPt = 0; outne[ipf].hwEta = 0; outne[ipf].hwPhi = 0; outne[ipf].hwId = 0; }
+
+    // for each track, find the closest calo
+    for (int it = 0; it < NTRACK; ++it) {
+        if (track[it].hwPt > 0 && !isEle[it] && !isMu[it]) {
+            int  ibest = best_match_with_pt_ref<NCALO,DR2MAX,HadCaloObj>(hadcalo_subem, track[it]);
+            //int  ibest = best_match_ref<NCALO,DR2MAX,true,HadCaloObj>(hadcalo_subem, track[it]);
+            if (ibest != -1) {
+                track_good[it] = 1;
+                calo_sumtk[ibest]    += track[it].hwPt;
+                calo_sumtkErr2[ibest] += sqr(track[it].hwPtErr);
+            }
+        }
+    }
+
+    for (int ic = 0; ic < NCALO; ++ic) {
+        if (calo_sumtk[ic] > 0) {
+            pt_t ptdiff = hadcalo_subem[ic].hwPt - calo_sumtk[ic];
+            if (ptdiff > 0 && ptdiff*ptdiff > 4*calo_sumtkErr2[ic]) {
+                calo_subpt[ic] = ptdiff;
+            } else {
+                calo_subpt[ic] = 0;
+            }
+        } else {
+            calo_subpt[ic] = hadcalo_subem[ic].hwPt;
+        }
+    }
+
+    // copy out charged hadrons
+    for (int it = 0; it < NTRACK; ++it) {
+        if (track_good[it]) {
+            outch[it].hwPt = track[it].hwPt;
+            outch[it].hwEta = track[it].hwEta;
+            outch[it].hwPhi = track[it].hwPhi;
+            outch[it].hwZ0 = track[it].hwZ0;
+            outch[it].hwId  = isEle[it] ? PID_Electron : (isMu[it] ? PID_Muon : PID_Charged);
+        }
+    }
+
+    // copy out neutral hadrons
+    PFNeutralObj outne_all[NCALO];
+    for (int ipf = 0; ipf < NCALO; ++ipf) { outne_all[ipf].hwPt = 0; outne_all[ipf].hwEta = 0; outne_all[ipf].hwPhi = 0; outne_all[ipf].hwId = 0; }
+    for (int ic = 0; ic < NCALO; ++ic) {
+        if (calo_subpt[ic] > 0) {
+            outne_all[ic].hwPt  = calo_subpt[ic];
+            outne_all[ic].hwEta = hadcalo_subem[ic].hwEta;
+            outne_all[ic].hwPhi = hadcalo_subem[ic].hwPhi;
+            outne_all[ic].hwId  = PID_Neutral;
+        }
+    }
+
+    ptsort_ref<PFNeutralObj,NCALO,NSELCALO>(outne_all, outne);
+
+}


### PR DESCRIPTION

On top of #26, modifications to allow running the discrete PF directly from the same `simple_fullpfalgo_ref.cpp` that we use in Vivado HLS as bitwise reference to the firmware version.


The following files are identical in FastPuppi and the Correlator_HLS repository (after this PR and https://github.com/p2l1pfp/GlobalCorrelator_HLS/pull/12):
  * `firmware/data.h` &rarr; `NtupleProducer/src/firmware/data.h`
  * `firmware/simple_fullpfalgo.h` &rarr; `NtupleProducer/src/firmware/simple_fullpfalgo.h`
  * `simple_fullpfalgo_ref.cpp` &rarr; `NtupleProducer/src/simple_fullpfalgo_ref.cpp`
  * `DiscretePF2Firmware.h` &rarr; `NtupleProducer/src/DiscretePF2Firmware.h` 
  * `DiscretePFInputs.h` &rarr; `NtupleProducer/interface/DiscretePFInputs.h` 
(**note different path, the CMSSW one has an `/interface/` while the HLS has not**)


some plots: https://gpetrucc.web.cern.ch/gpetrucc/drop/plots/l1stage2/Spring17D/inputs/vivado