### PR TITLE
Firmware-friendly switches and tunings of the PF algo

### DIFF
--- a/NtupleProducer/interface/AlternativePF.h
+++ b/NtupleProducer/interface/AlternativePF.h
@@ -16,7 +16,7 @@ class PFAlgo3 : public PFAlgo {
         float drMatchEm_, ptMinFracMatchEm_, drMatchEmHad_;
         TkCaloLinkMetric tkCaloLinkMetric_;
         bool caloReLinkStep_; float caloReLinkDr_, caloReLinkThreshold_;
-        bool rescaleTracks_, sumTkCaloErr2_, ecalPriority_;
+        bool rescaleTracks_, sumTkCaloErr2_, ecalPriority_, trackEmUseAlsoTrackSigma_, emCaloUseAlsoCaloSigma_;
         unsigned int tightTrackMinStubs_; float tightTrackMaxChi2_, tightTrackMaxInvisiblePt_;
         enum GoodTrackStatus { GoodTK_Calo_TkPt=0, GoodTK_Calo_TkCaloPt=1, GoodTk_Calo_CaloPt=2, GoodTK_NoCalo=3 };
         enum BadTrackStatus { BadTK_NoCalo=1 };

--- a/NtupleProducer/interface/AlternativePF.h
+++ b/NtupleProducer/interface/AlternativePF.h
@@ -10,6 +10,8 @@ class PFAlgo3 : public PFAlgo {
         PFAlgo3( const edm::ParameterSet& ) ;
         virtual void runPF(Region &r) const override;
     protected:
+        float drMatchMu_;
+        enum MuMatchMode { BoxBestByPtRatio, DrBestByPtRatio, DrBestByPtDiff } muMatchMode_;
         enum TkCaloLinkMetric { BestByDR=0, BestByDRPt=1 };
         float drMatchEm_, ptMinFracMatchEm_, drMatchEmHad_;
         TkCaloLinkMetric tkCaloLinkMetric_;
@@ -18,6 +20,9 @@ class PFAlgo3 : public PFAlgo {
         unsigned int tightTrackMinStubs_; float tightTrackMaxChi2_, tightTrackMaxInvisiblePt_;
         enum GoodTrackStatus { GoodTK_Calo_TkPt=0, GoodTK_Calo_TkCaloPt=1, GoodTk_Calo_CaloPt=2, GoodTK_NoCalo=3 };
         enum BadTrackStatus { BadTK_NoCalo=1 };
+
+        /// do muon track linking (also sets track.muonLink)
+        void link_tk2mu(Region &r, std::vector<int> & tk2mu, std::vector<int> & mu2tk) const ;
 
         /// match all tracks to the closest EM cluster
         //  tk2em[itrack] = iem, or -1 if unmatched

--- a/NtupleProducer/interface/AlternativePF.h
+++ b/NtupleProducer/interface/AlternativePF.h
@@ -12,7 +12,7 @@ class PFAlgo3 : public PFAlgo {
     protected:
         float drMatchMu_;
         enum MuMatchMode { BoxBestByPtRatio, DrBestByPtRatio, DrBestByPtDiff } muMatchMode_;
-        enum TkCaloLinkMetric { BestByDR=0, BestByDRPt=1 };
+        enum TkCaloLinkMetric { BestByDR=0, BestByDRPt=1, BestByDR2Pt2=2 };
         float drMatchEm_, ptMinFracMatchEm_, drMatchEmHad_;
         TkCaloLinkMetric tkCaloLinkMetric_;
         bool caloReLinkStep_; float caloReLinkDr_, caloReLinkThreshold_;

--- a/NtupleProducer/interface/DiscretePF.h
+++ b/NtupleProducer/interface/DiscretePF.h
@@ -44,13 +44,27 @@ namespace l1tpf_int {
     unsigned int nOutput(OutputType type, bool puppi) const ;
 
     // global coordinates
-    bool contains(float eta, float phi) const { return (etaMin-etaExtra <= eta && eta <= etaMax+etaExtra && std::abs(deltaPhi(phiCenter,phi)) <= phiHalfWidth+phiExtra); }
+    bool contains(float eta, float phi) const { 
+        float dphi = deltaPhi(phiCenter,phi);
+        return (etaMin-etaExtra < eta && eta <= etaMax+etaExtra && 
+                -phiHalfWidth-phiExtra < dphi && dphi <= phiHalfWidth+phiExtra); 
+    }
     // global coordinates
-    bool fiducial(float eta, float phi) const { return (etaMin <= eta && eta <= etaMax && std::abs(deltaPhi(phiCenter,phi)) <= phiHalfWidth); }
+    bool fiducial(float eta, float phi) const { 
+        float dphi = deltaPhi(phiCenter,phi);
+        return (etaMin < eta && eta <= etaMax && 
+                -phiHalfWidth < dphi && dphi <= phiHalfWidth); 
+    }
     // possibly local coordinates
     bool fiducialLocal(float localEta, float localPhi) const { 
-        if (relativeCoordinates) return (etaMin <= localEta+etaCenter && localEta+etaCenter <= etaMax && std::abs(deltaPhi(0.f,localPhi)) <= phiHalfWidth); 
-        return (etaMin <= localEta && localEta <= etaMax && std::abs(deltaPhi(phiCenter,localPhi)) <= phiHalfWidth); 
+        if (relativeCoordinates) {
+            float dphi = deltaPhi(0.f,localPhi);
+            return (etaMin < localEta+etaCenter && localEta+etaCenter <= etaMax && 
+                -phiHalfWidth < dphi && dphi <= phiHalfWidth); 
+        }
+        float dphi = deltaPhi(phiCenter,localPhi);
+        return (etaMin < localEta && localEta <= etaMax && 
+                -phiHalfWidth < dphi && dphi <= phiHalfWidth); 
     }
     float regionAbsEta() const { return std::abs(etaCenter); }
     float globalAbsEta(float localEta) const { return std::abs(relativeCoordinates ? localEta + etaCenter : localEta); }

--- a/NtupleProducer/interface/DiscretePF.h
+++ b/NtupleProducer/interface/DiscretePF.h
@@ -99,6 +99,7 @@ namespace l1tpf_int {
     protected:
         std::vector<Region> regions_;
         bool useRelativeRegionalCoordinates_; // whether the eta,phi in each region are global or relative to the region center
+        enum TrackAssoMode { atVertex, atCalo, any=999 } trackRegionMode_;
   };
 
   class PFAlgo {

--- a/NtupleProducer/interface/DiscretePFInputs.h
+++ b/NtupleProducer/interface/DiscretePFInputs.h
@@ -13,6 +13,7 @@
 
 #include <cassert>
 #include <cstdlib>
+#include <cstdio>
 #include <cmath>
 #include <vector>
 

--- a/NtupleProducer/plugins/NtupleProducer.cc
+++ b/NtupleProducer/plugins/NtupleProducer.cc
@@ -293,6 +293,7 @@ NtupleProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
       tk.setCaloSigma(simpleResolHad_(tk.pt(), std::abs(tk.eta())));
       if (fDebug > 1) printf("tk %7.2f eta %+4.2f has sigma %4.2f  sigma/pt %5.3f, calo sigma/pt %5.3f, stubs %2d, chi2 %7.1f\n", tk.pt(), tk.eta(), tk.sigma(), tk.sigma()/tk.pt(), tk.caloSigma()/tk.pt(), int(tk.quality()),tk.normalizedChi2());
       // adding objects to PF
+      if (fDebugR > 0 && deltaR(tk.eta(),tk.phi(),fDebugEta,fDebugPhi) > fDebugR) continue;
       if(tk.pt() > trkPt_ && unsigned(tk.quality()) >= trkMinStubs_ && tk.normalizedChi2() < trkMaxChi2_ ) l1regions_.addTrack(tk);      
       /// filling the tree    
       if (!fTrkInfoTree) continue;
@@ -327,7 +328,7 @@ NtupleProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   std::vector<l1tpf::Particle> l1mus(*hl1mus);
   for (l1tpf::Particle & mu : l1mus) { // no const & since we modify it to set the sigma
       // possible debug filtering of inputs in some area
-      if (fDebugR > 0 && deltaR(mu.eta(),mu.phi(),fDebugEta,fDebugPhi) < fDebugR) continue;
+      if (fDebugR > 0 && deltaR(mu.eta(),mu.phi(),fDebugEta,fDebugPhi) > fDebugR) continue;
       // set resolution
       mu.setSigma(simpleResolTrk_(mu.pt(), std::abs(mu.eta())));  // this needs to be updated with the muon resolutions!
       // add to inputs
@@ -380,11 +381,11 @@ NtupleProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
   // pass to the PF algo
   for (const l1tpf::Particle & calo : calos) {
-      if (fDebugR > 0 && deltaR(calo.eta(),calo.phi(),fDebugEta,fDebugPhi) < fDebugR) continue;
+      if (fDebugR > 0 && deltaR(calo.eta(),calo.phi(),fDebugEta,fDebugPhi) > fDebugR) continue;
       l1regions_.addCalo(calo); 
   }
   for (const l1tpf::Particle & calo : emcalos) {
-      if (fDebugR > 0 && deltaR(calo.eta(),calo.phi(),fDebugEta,fDebugPhi) < fDebugR) continue;
+      if (fDebugR > 0 && deltaR(calo.eta(),calo.phi(),fDebugEta,fDebugPhi) > fDebugR) continue;
       l1regions_.addEmCalo(calo); 
   }
 

--- a/NtupleProducer/python/ntupleProducer_cfi.py
+++ b/NtupleProducer/python/ntupleProducer_cfi.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
+from math import sqrt
+
 InfoOut = cms.EDProducer('NtupleProducer',
          #L1TrackTag  = cms.InputTag('l1tPFTkProducersFromOfflineTracksStrips'),
          L1TrackTag  = cms.InputTag('l1tPFTkProducersFromL1Tracks'),
@@ -46,7 +48,7 @@ InfoOut = cms.EDProducer('NtupleProducer',
                         #trackCaloLinkMetric = cms.string("bestByDR"),
                         trackCaloDR = cms.double(0.12),
                         trackCaloNSigmaLow  = cms.double(2.0),
-                        trackCaloNSigmaHigh = cms.double(1.2),
+                        trackCaloNSigmaHigh = cms.double(sqrt(1.5)), # optimization gave 1.2, but sqrt(1.5) is easier to implement in hardware
                         useTrackCaloSigma = cms.bool(True), # take the uncertainty on the calo cluster from the track, for linking purposes
                         sumTkCaloErr2 = cms.bool(True), # add up track calo errors in quadrature instead of linearly
                         rescaleTracks = cms.bool(False), # if tracks exceed the calo, rescale the track momenta

--- a/NtupleProducer/python/ntupleProducer_cfi.py
+++ b/NtupleProducer/python/ntupleProducer_cfi.py
@@ -33,6 +33,9 @@ InfoOut = cms.EDProducer('NtupleProducer',
          vtxAdaptiveCut = cms.bool(True),
          linking = cms.PSet(
                         algo = cms.string("PFAlgo3"),
+                        # track -> mu linking configurables
+                        trackMuDR    = cms.double(0.2), # accounts for poor resolution of standalone, and missing propagations
+                        trackMuMatch = cms.string("boxBestByPtRatio"), # also drBestByPtRatio
                         # track -> em linking configurables
                         trackEmDR   = cms.double(0.04), # 1 Ecal crystal size is 0.02, and ~2 cm in HGCal is ~0.007
                         # em -> calo linking configurables

--- a/NtupleProducer/python/ntupleProducer_cfi.py
+++ b/NtupleProducer/python/ntupleProducer_cfi.py
@@ -40,9 +40,11 @@ InfoOut = cms.EDProducer('NtupleProducer',
                         trackMuMatch = cms.string("boxBestByPtRatio"), # also drBestByPtRatio
                         # track -> em linking configurables
                         trackEmDR   = cms.double(0.04), # 1 Ecal crystal size is 0.02, and ~2 cm in HGCal is ~0.007
+                        trackEmUseAlsoTrackSigma = cms.bool(True), # also use the track uncertainty for electron linking
                         # em -> calo linking configurables
                         emCaloDR    = cms.double(0.10),    # 1 Hcal tower size is ~0.09
                         caloEmPtMinFrac = cms.double(0.5), # Calo object must have an EM Et at least half of that of the EM cluster to allow linking
+                        emCaloUseAlsoCaloSigma = cms.bool(True), # also use the track uncertainty for electron linking
                         # track -> calo linking configurables
                         trackCaloLinkMetric = cms.string("bestByDRPt"),
                         #trackCaloLinkMetric = cms.string("bestByDR"),

--- a/NtupleProducer/python/runRespNTupler.py
+++ b/NtupleProducer/python/runRespNTupler.py
@@ -129,7 +129,7 @@ def goRegional(inParallel=False):
     else:
         process.InfoOut.regions = regions
         process.InfoOut.useRelativeRegionalCoordinates = cms.bool(True)
-def gbr(neta,nphi,etaex=0.3,phiex=0.2):
+def gbr(neta,nphi,etaex=0.3,phiex=0.2,mode="any"):
     regions = cms.VPSet(
             cms.PSet(
                 etaBoundaries = cms.vdouble(*[(-1.5+3*i/neta) for i in xrange(neta+1)]),
@@ -140,6 +140,7 @@ def gbr(neta,nphi,etaex=0.3,phiex=0.2):
     )
     process.InfoOut.regions = regions
     process.InfoOut.useRelativeRegionalCoordinates = cms.bool(True)
+    process.InfoOut.trackRegionMode = cms.string(mode)
 if False:
     process.InfoOut.fillTrackTree = cms.untracked.int32(1)
     process.source.fileNames = ['file:/eos/cms/store/cmst3/user/gpetrucc/l1phase2/Spring17D/200517/inputs_17D_TTbar_PU0_job1.root' ]
@@ -150,10 +151,14 @@ if False: # run bitwise PF for Vivado
     process.InfoOut.useRelativeRegionalCoordinates = cms.bool(True)
     process.InfoOut.linking.algo = "BitwisePF"
     process.source.fileNames = ['file:/eos/cms/store/cmst3/user/jngadiub/L1PFInputs/SinglePion_PU0/inputs_17D_SinglePion_PU0_job1.root', ]
-if False: # prepare dump file for Vivado
+if True: # prepare dump file for Vivado (PF IP core)
     goRegional()
     process.InfoOut.useRelativeRegionalCoordinates = cms.bool(True)
     process.InfoOut.regionDumpFileName = cms.untracked.string("regions_TTbar_PU140.dump")
+    process.source.fileNames = ['file:/eos/cms/store/cmst3/user/jngadiub/L1PFInputs/TTbar_PU140/inputs_17D_TTbar_PU140_job1.root'] #, 'file:/eos/cms/store/cmst3/user/jngadiub/L1PFInputs/TTbar_PU140/inputs_17D_TTbar_PU140_job2.root', 'file:/eos/cms/store/cmst3/user/jngadiub/L1PFInputs/TTbar_PU140/inputs_17D_TTbar_PU140_job3.root', 'file:/eos/cms/store/cmst3/user/jngadiub/L1PFInputs/TTbar_PU140/inputs_17D_TTbar_PU140_job4.root', 'file:/eos/cms/store/cmst3/user/jngadiub/L1PFInputs/TTbar_PU140/inputs_17D_TTbar_PU140_job5.root', 'file:/eos/cms/store/cmst3/user/jngadiub/L1PFInputs/TTbar_PU140/inputs_17D_TTbar_PU140_job6.root', ]
+if True: # prepare dump file for Vivado (Regionizer)
+    gbr(1,12,0,0,"atCalo")
+    process.InfoOut.regionDumpFileName = cms.untracked.string("barrel_sectors_1x12_TTbar_PU140.dump")
     process.source.fileNames = ['file:/eos/cms/store/cmst3/user/jngadiub/L1PFInputs/TTbar_PU140/inputs_17D_TTbar_PU140_job1.root'] #, 'file:/eos/cms/store/cmst3/user/jngadiub/L1PFInputs/TTbar_PU140/inputs_17D_TTbar_PU140_job2.root', 'file:/eos/cms/store/cmst3/user/jngadiub/L1PFInputs/TTbar_PU140/inputs_17D_TTbar_PU140_job3.root', 'file:/eos/cms/store/cmst3/user/jngadiub/L1PFInputs/TTbar_PU140/inputs_17D_TTbar_PU140_job4.root', 'file:/eos/cms/store/cmst3/user/jngadiub/L1PFInputs/TTbar_PU140/inputs_17D_TTbar_PU140_job5.root', 'file:/eos/cms/store/cmst3/user/jngadiub/L1PFInputs/TTbar_PU140/inputs_17D_TTbar_PU140_job6.root', ]
      
 if False:

--- a/NtupleProducer/python/runRespNTupler.py
+++ b/NtupleProducer/python/runRespNTupler.py
@@ -169,6 +169,8 @@ def comp4():
     process.InfoOut.linking.ecalPriority = False 
     process.InfoOut.linking.trackMuMatch = "drBestByPtDiff" 
     process.InfoOut.linking.trackCaloLinkMetric = "bestByDR2Pt2"
+    process.InfoOut.linking.trackEmUseAlsoTrackSigma = False 
+    process.InfoOut.linking.emCaloUseAlsoCaloSigma = False
     process.InfoOutSimpler = process.InfoOut.clone()
     process.InfoOut.linking.algo = "BitwisePF"
     process.p.replace(process.InfoOut, process.InfoOutGlobal + process.InfoOutRegional + process.InfoOutSimpler + process.InfoOut)
@@ -182,6 +184,8 @@ if False:
         process.InfoOut.linking.ecalPriority = False 
         process.InfoOut.linking.trackMuMatch = "drBestByPtDiff" 
         process.InfoOut.linking.trackCaloLinkMetric = "bestByDR2Pt2"
+        process.InfoOut.linking.trackEmUseAlsoTrackSigma = False 
+        process.InfoOut.linking.emCaloUseAlsoCaloSigma = False
         process.InfoOut.altDebug = cms.untracked.int32(1)
         #process.CaloInfoOutBackup = process.CaloInfoOut.clone()
         process.InfoOutBackup = process.InfoOut.clone()
@@ -190,7 +194,8 @@ if False:
         process.InfoOut.linking.algo = "BitwisePF"
         process.InfoOut.bitwiseDebug = cms.untracked.int32(1)
         process.ntuple.objects.L1PFBackup = cms.VInputTag("InfoOutBackup:PF",)
-    #comp4();
+    else:
+        comp4();
     #process.source.fileNames = ['file:/eos/cms/store/cmst3/user/jngadiub/L1PFInputs/TTbar_PU140/inputs_17D_TTbar_PU140_job1.root'] 
     process.source.fileNames = ['file:/eos/cms/store/cmst3/user/jngadiub/L1PFInputs/TTbar_PU0/inputs_17D_TTbar_PU0_job51.root'] 
     process.out = cms.OutputModule("PoolOutputModule",

--- a/NtupleProducer/python/runRespNTupler.py
+++ b/NtupleProducer/python/runRespNTupler.py
@@ -168,6 +168,7 @@ def comp4():
     process.InfoOutRegional = process.InfoOut.clone()
     process.InfoOut.linking.ecalPriority = False 
     process.InfoOut.linking.trackMuMatch = "drBestByPtDiff" 
+    process.InfoOut.linking.trackCaloLinkMetric = "bestByDR2Pt2"
     process.InfoOutSimpler = process.InfoOut.clone()
     process.InfoOut.linking.algo = "BitwisePF"
     process.p.replace(process.InfoOut, process.InfoOutGlobal + process.InfoOutRegional + process.InfoOutSimpler + process.InfoOut)
@@ -180,6 +181,7 @@ if False:
         process.InfoOut.useRelativeRegionalCoordinates = cms.bool(True)
         process.InfoOut.linking.ecalPriority = False 
         process.InfoOut.linking.trackMuMatch = "drBestByPtDiff" 
+        process.InfoOut.linking.trackCaloLinkMetric = "bestByDR2Pt2"
         process.InfoOut.altDebug = cms.untracked.int32(1)
         #process.CaloInfoOutBackup = process.CaloInfoOut.clone()
         process.InfoOutBackup = process.InfoOut.clone()

--- a/NtupleProducer/python/scripts/objMultiplicityPlot.py
+++ b/NtupleProducer/python/scripts/objMultiplicityPlot.py
@@ -12,12 +12,15 @@ from math import *
 from optparse import OptionParser
 parser = OptionParser("%(prog) infile [ src [ dst ] ]")
 parser.add_option("--cl", type=float, dest="cl", default=0, help="Compute number to avoid truncations at this CL")
+parser.add_option("-p", type="string", dest="particles", action="append", default=[], help="objects to count")
 options, args = parser.parse_args()
-
-odir = args[1] # "plots/910pre2/test"
-os.system("mkdir -p "+odir)
-os.system("cp %s/src/FastPUPPI/NtupleProducer/python/display/index.php %s/" % (os.environ['CMSSW_BASE'], odir));
-ROOT.gROOT.ProcessLine(".x %s/src/FastPUPPI/NtupleProducer/python/display/tdrstyle.cc" % os.environ['CMSSW_BASE']);
+if options.cl == 0:
+    odir = args[1] # "plots/910pre2/test"
+    os.system("mkdir -p "+odir)
+    os.system("cp %s/src/FastPUPPI/NtupleProducer/python/display/index.php %s/" % (os.environ['CMSSW_BASE'], odir));
+    ROOT.gROOT.ProcessLine(".x %s/src/FastPUPPI/NtupleProducer/python/display/tdrstyle.cc" % os.environ['CMSSW_BASE']);
+elif options.cl >= 1:
+    raise RuntimeError("--cl must take an argument stricly between 0 and 1")
 c1 = ROOT.TCanvas("c1","c1")
 particles = [ "Calo", "EmCalo", "Mu", "TK" ]
 for Algo in "PF", "Puppi":
@@ -28,6 +31,7 @@ tfile = ROOT.TFile.Open(args[0])
 tree = tfile.Get("ntuple/tree")
 ROOT.gStyle.SetOptStat("omr")
 for particle in particles:
+    if options.particles and (particle not in options.particles): continue
     if options.cl > 0:
         n = tree.Draw("min(maxNL1%s,199)>>htemp(200,-0.5,199.5)" % (particle), "mc_id == 998", "")
         if not n: continue

--- a/NtupleProducer/python/scripts/respPlots.py
+++ b/NtupleProducer/python/scripts/respPlots.py
@@ -294,6 +294,12 @@ whats = [
         ("APuppiCh",       "AltPuppiCharged$",           ROOT.kGreen+3, 21, 1.1),
         ("APuppiNh",       "AltPuppi$-AltPuppiCharged$", ROOT.kGreen+1, 21, 1.1),
     ]),
+    ('pfcomp4',[
+        ("Global",    "L1PFGlobal$",   ROOT.kGreen+1,  20, 1.2),
+        ("Regional",  "L1PFRegional$", ROOT.kAzure+1,  24, 1.2),
+        ("Simpler",   "L1PFSimpler$",  ROOT.kViolet+1, 21, 1.1),
+        ("Firmware",  "L1PF$",         ROOT.kOrange+7, 34, 1.2),
+    ]),
 
 
 

--- a/NtupleProducer/src/AlternativePF.cc
+++ b/NtupleProducer/src/AlternativePF.cc
@@ -325,10 +325,10 @@ void PFAlgo3::sub_em2calo(Region & r, const std::vector<int> & em2calo) const {
             }
         }
         if (pt < pt0) {
-            if (debug_) printf("ALT \t calo  %3d (pt %7.2f +- %7.2f) has a subtracted pt of %7.2f, empt %7.2f -> %7.2f\n", ic, calo.floatPt(), calo.floatPtErr(), pt, ept0, ept);
+            if (debug_) printf("ALT \t calo  %3d (pt %7.2f +- %7.2f) has a subtracted pt of %7.2f, empt %7.2f -> %7.2f, isem %d\n", ic, calo.floatPt(), calo.floatPtErr(), pt, ept0, ept, calo.isEM);
             calo.setFloatPt(pt);
             calo.setFloatEmPt(ept);
-            if (!keepme && (pt < calo.floatPtErr() || pt < 0.125*pt0 || (calo.isEM && ept < 0.125*ept0))) {
+            if (!keepme && (pt < calo.floatPtErr() || pt <= 0.125*pt0 || (calo.isEM && ept <= 0.125*ept0))) { // the <= is important since in firmware the pt0/8 can be zero
                 if (debug_) printf("ALT \t calo  %3d (pt %7.2f)    ----> discarded\n", ic, calo.floatPt());
                 calo.used = true;
                 calo.setFloatPt(pt0); discardCalo(r, calo, 1);  // log this as discarded, for debugging

--- a/NtupleProducer/src/AlternativePF.cc
+++ b/NtupleProducer/src/AlternativePF.cc
@@ -327,7 +327,7 @@ void PFAlgo3::sub_em2calo(Region & r, const std::vector<int> & em2calo) const {
             if (debug_) printf("ALT \t calo  %3d (pt %7.2f +- %7.2f) has a subtracted pt of %7.2f, empt %7.2f -> %7.2f\n", ic, calo.floatPt(), calo.floatPtErr(), pt, ept0, ept);
             calo.setFloatPt(pt);
             calo.setFloatEmPt(ept);
-            if (!keepme && (pt < calo.floatPtErr() || pt < 0.1*pt0 || (calo.isEM && ept < 0.1*ept0))) {
+            if (!keepme && (pt < calo.floatPtErr() || pt < 0.125*pt0 || (calo.isEM && ept < 0.125*ept0))) {
                 if (debug_) printf("ALT \t calo  %3d (pt %7.2f)    ----> discarded\n", ic, calo.floatPt());
                 calo.used = true;
                 calo.setFloatPt(pt0); discardCalo(r, calo, 1);  // log this as discarded, for debugging

--- a/NtupleProducer/src/AlternativePF.cc
+++ b/NtupleProducer/src/AlternativePF.cc
@@ -43,7 +43,7 @@ void PFAlgo3::runPF(Region &r) const {
 
     if (debug_) {
         printf("ALT \t region Eta [ %+5.2f , %+5.2f ],  Phi [ %+5.2f , %+5.2f ] \n", r.etaMin, r.etaMax, r.phiCenter-r.phiHalfWidth, r.phiCenter+r.phiHalfWidth );
-        printf("ALT \t N(track) %3lu   N(em) %3lu   N(calo) %3lu\n", r.track.size(), r.emcalo.size(), r.calo.size());
+        printf("ALT \t N(track) %3lu   N(em) %3lu   N(calo) %3lu   N(mu) %3lu\n", r.track.size(), r.emcalo.size(), r.calo.size(), r.muon.size());
         for (int itk = 0, ntk = r.track.size(); itk < ntk; ++itk) {
             const auto & tk = r.track[itk]; 
             printf("ALT \t track %3d: pt %7.2f +- %5.2f  vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f calo ptErr %7.2f stubs %2d chi2 %7.1f\n", 
@@ -59,6 +59,12 @@ void PFAlgo3::runPF(Region &r) const {
             printf("ALT \t calo  %3d: pt %7.2f +- %5.2f  vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f calo ptErr %7.2f em pt %7.2f \n", 
                                 ic, calo.floatPt(), calo.floatPtErr(), calo.floatEta(), calo.floatPhi(), calo.floatEta(), calo.floatPhi(), calo.floatPtErr(), calo.floatEmPt());
         }
+        for (int im = 0, nm = r.muon.size(); im < nm; ++im) {
+            auto & mu = r.muon[im]; 
+            printf("ALT \t muon  %3d: pt %7.2f           vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f \n", 
+                                im, mu.floatPt(), mu.floatEta(), mu.floatPhi(), mu.floatEta(), mu.floatPhi());
+        }
+
     }
 
     // match all tracks to the closest EM cluster

--- a/NtupleProducer/src/AlternativePF.cc
+++ b/NtupleProducer/src/AlternativePF.cc
@@ -46,7 +46,7 @@ void PFAlgo3::runPF(Region &r) const {
     /// ------------- first step (can all go in parallel) ----------------
 
     if (debug_) {
-        printf("ALT \t region Eta [ %+5.2f , %+5.2f ],  Phi [ %+5.2f , %+5.2f ] \n", r.etaMin, r.etaMax, r.phiCenter-r.phiHalfWidth, r.phiCenter+r.phiHalfWidth );
+        printf("ALT\nALT region Eta [ %+5.2f , %+5.2f ],  Phi [ %+5.2f , %+5.2f ] \n", r.etaMin, r.etaMax, r.phiCenter-r.phiHalfWidth, r.phiCenter+r.phiHalfWidth );
         printf("ALT \t N(track) %3lu   N(em) %3lu   N(calo) %3lu   N(mu) %3lu\n", r.track.size(), r.emcalo.size(), r.calo.size(), r.muon.size());
         for (int itk = 0, ntk = r.track.size(); itk < ntk; ++itk) {
             const auto & tk = r.track[itk]; 
@@ -362,7 +362,7 @@ void PFAlgo3::link_tk2calo(Region & r, std::vector<int> & tk2calo) const {
                     break;
             }
         }
-        if (debug_ && tk2calo[itk] != -1) printf("ALT \t track %3d (pt %7.2f) matches to calo %3d (pt %7.2f) with dr %.3f\n", itk, tk.floatPt(), tk2calo[itk], tk2calo[itk] == -1 ? 0.0 : r.calo[tk2calo[itk]].floatPt(), drbest );
+        if (debug_ && tk2calo[itk] != -1) printf("ALT \t track %3d (pt %7.2f) matches to calo %3d (pt %7.2f) with dist %.3f\n", itk, tk.floatPt(), tk2calo[itk], tk2calo[itk] == -1 ? 0.0 : r.calo[tk2calo[itk]].floatPt(), drbest );
         // now we re-do this for debugging sake, it may be done for real later
         if (debug_ && tk2calo[itk] == -1) {
             int ibest = -1; drbest = 0.3;

--- a/NtupleProducer/src/BitwisePF.cc
+++ b/NtupleProducer/src/BitwisePF.cc
@@ -18,13 +18,14 @@ BitwisePF::BitwisePF( const edm::ParameterSet & iConfig ) :
     PFAlgo(iConfig)
 {
     debug_ = iConfig.getUntrackedParameter<int>("bitwiseDebug", debug_);
+    pfalgo3_full_ref_set_debug(debug_);
 }
 
 void BitwisePF::runPF(Region &r) const {
     initRegion(r);
 
     if (debug_) {
-        printf("BW  \t region Eta [ %+5.2f , %+5.2f ],  Phi [ %+5.2f , %+5.2f ] \n", r.etaMin, r.etaMax, r.phiCenter-r.phiHalfWidth, r.phiCenter+r.phiHalfWidth );
+        printf("BW\nBW  region Eta [ %+5.2f , %+5.2f ],  Phi [ %+5.2f , %+5.2f ] \n", r.etaMin, r.etaMax, r.phiCenter-r.phiHalfWidth, r.phiCenter+r.phiHalfWidth );
         printf("BW  \t N(track) %3lu   N(em) %3lu   N(calo) %3lu   N(mu) %3lu\n", r.track.size(), r.emcalo.size(), r.calo.size(), r.muon.size());
         for (int itk = 0, ntk = r.track.size(); itk < ntk; ++itk) {
             const auto & tk = r.track[itk]; 

--- a/NtupleProducer/src/BitwisePF.cc
+++ b/NtupleProducer/src/BitwisePF.cc
@@ -24,22 +24,27 @@ void BitwisePF::runPF(Region &r) const {
     initRegion(r);
 
     if (debug_) {
-        printf("ALT \t region Eta [ %+5.2f , %+5.2f ],  Phi [ %+5.2f , %+5.2f ] \n", r.etaMin, r.etaMax, r.phiCenter-r.phiHalfWidth, r.phiCenter+r.phiHalfWidth );
-        printf("ALT \t N(track) %3lu   N(em) %3lu   N(calo) %3lu\n", r.track.size(), r.emcalo.size(), r.calo.size());
+        printf("BW  \t region Eta [ %+5.2f , %+5.2f ],  Phi [ %+5.2f , %+5.2f ] \n", r.etaMin, r.etaMax, r.phiCenter-r.phiHalfWidth, r.phiCenter+r.phiHalfWidth );
+        printf("BW  \t N(track) %3lu   N(em) %3lu   N(calo) %3lu   N(mu) %3lu\n", r.track.size(), r.emcalo.size(), r.calo.size(), r.muon.size());
         for (int itk = 0, ntk = r.track.size(); itk < ntk; ++itk) {
             const auto & tk = r.track[itk]; 
-            printf("ALT \t track %3d: pt %7.2f +- %5.2f  vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f calo ptErr %7.2f stubs %2d chi2 %7.1f\n", 
+            printf("BW  \t track %3d: pt %7.2f +- %5.2f  vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f calo ptErr %7.2f stubs %2d chi2 %7.1f\n", 
                                 itk, tk.floatPt(), tk.floatPtErr(), tk.floatVtxEta(), tk.floatVtxPhi(), tk.floatEta(), tk.floatPhi(), tk.floatCaloPtErr(), int(tk.hwStubs), tk.hwChi2*0.1f);
         }
         for (int iem = 0, nem = r.emcalo.size(); iem < nem; ++iem) {
             const auto & em = r.emcalo[iem];
-            printf("ALT \t EM    %3d: pt %7.2f +- %5.2f  vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f calo ptErr %7.2f\n", 
+            printf("BW  \t EM    %3d: pt %7.2f +- %5.2f  vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f calo ptErr %7.2f\n", 
                                 iem, em.floatPt(), em.floatPtErr(), em.floatEta(), em.floatPhi(), em.floatEta(), em.floatPhi(), em.floatPtErr());
         } 
         for (int ic = 0, nc = r.calo.size(); ic < nc; ++ic) {
             auto & calo = r.calo[ic]; 
-            printf("ALT \t calo  %3d: pt %7.2f +- %5.2f  vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f calo ptErr %7.2f em pt %7.2f \n", 
+            printf("BW  \t calo  %3d: pt %7.2f +- %5.2f  vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f calo ptErr %7.2f em pt %7.2f \n", 
                                 ic, calo.floatPt(), calo.floatPtErr(), calo.floatEta(), calo.floatPhi(), calo.floatEta(), calo.floatPhi(), calo.floatPtErr(), calo.floatEmPt());
+        }
+        for (int im = 0, nm = r.muon.size(); im < nm; ++im) {
+            auto & mu = r.muon[im]; 
+            printf("BW  \t muon  %3d: pt %7.2f           vtx eta %+5.2f  vtx phi %+5.2f  calo eta %+5.2f  calo phi %+5.2f \n", 
+                                im, mu.floatPt(), mu.floatEta(), mu.floatPhi(), mu.floatEta(), mu.floatPhi());
         }
     }
 

--- a/NtupleProducer/src/DiscretePF.cc
+++ b/NtupleProducer/src/DiscretePF.cc
@@ -173,7 +173,13 @@ std::vector<l1tpf::Particle> RegionMapper::fetch(bool puppi, float ptMin, bool d
     for (const Region &r : regions_) {
         for (const PFParticle & p : (puppi ? r.puppi : (discarded ? r.pfdiscarded : r.pf ))) {
             if (regions_.size() > 1) {
-                if (!r.fiducialLocal(p.floatVtxEta(), p.floatVtxPhi())) continue;
+                bool inside = true;
+                switch (trackRegionMode_) {
+                    case atVertex: inside = r.fiducialLocal(p.floatVtxEta(), p.floatVtxPhi()); break;
+                    case atCalo  : inside = r.fiducialLocal(p.floatEta(), p.floatPhi()); break;
+                    case any     : inside = r.fiducialLocal(p.floatVtxEta(), p.floatVtxPhi()); break; // WARNING: this may not be the best choice
+                }
+                if (!inside) continue;
             }
             if (p.floatPt() > ptMin) {
                 ret.emplace_back( p.floatPt(), r.globalEta(p.floatVtxEta()), r.globalPhi(p.floatVtxPhi()), 0.13f, p.hwId, 0.f, p.floatDZ(), r.globalEta(p.floatEta()), r.globalPhi(p.floatPhi()), p.intCharge()  );

--- a/NtupleProducer/src/DiscretePF2Firmware.h
+++ b/NtupleProducer/src/DiscretePF2Firmware.h
@@ -15,6 +15,7 @@ namespace dpf2fw {
         out.hwEta = in.hwEta; // @calo
         out.hwPhi = in.hwPhi; // @calo
         out.hwZ0 = in.hwZ0;
+        out.hwTightQuality = (in.hwStubs >= 6 && in.hwChi2 < 500);
     }
     void convert(const l1tpf_int::CaloCluster & in, HadCaloObj & out) {
         out.hwPt = in.hwPt;

--- a/NtupleProducer/src/DiscretePF2Firmware.h
+++ b/NtupleProducer/src/DiscretePF2Firmware.h
@@ -41,6 +41,9 @@ namespace dpf2fw {
         for (unsigned int i = 0, n = std::min<unsigned int>(NMAX, in.size()); i < n; ++i) {
             convert(in[i], out[i]);
         }
+        for (unsigned int i = in.size(); i < NMAX; ++i) {
+            clear(out[i]);
+        }
     }
 
 

--- a/NtupleProducer/src/Firmware2DiscretePF.h
+++ b/NtupleProducer/src/Firmware2DiscretePF.h
@@ -10,7 +10,7 @@
 namespace fw2dpf {
 
     // convert inputs from discrete to firmware
-    void convert(const PFChargedObj & src, const l1tpf_int::PropagatedTrack & track, std::vector<l1tpf_int::PFParticle> &out) {
+    inline void convert(const PFChargedObj & src, const l1tpf_int::PropagatedTrack & track, std::vector<l1tpf_int::PFParticle> &out) {
         l1tpf_int::PFParticle pf;
         pf.hwPt = src.hwPt;
         pf.hwEta = src.hwEta;
@@ -27,7 +27,7 @@ namespace fw2dpf {
         pf.hwStatus = 0;
         out.push_back(pf);
     }
-    void convert(const PFNeutralObj & src, std::vector<l1tpf_int::PFParticle> &out) {
+    inline void convert(const PFNeutralObj & src, std::vector<l1tpf_int::PFParticle> &out) {
         l1tpf_int::PFParticle pf;
         pf.hwPt = src.hwPt;
         pf.hwEta = src.hwEta;
@@ -43,6 +43,34 @@ namespace fw2dpf {
         pf.hwStatus = 0;
         out.push_back(pf);
     }
+
+    // convert inputs from discrete to firmware
+    inline void convert(const TkObj & in, l1tpf_int::PropagatedTrack & out) {
+        out.hwPt = in.hwPt;
+        out.hwCaloPtErr = in.hwPtErr;
+        out.hwEta = in.hwEta; // @calo
+        out.hwPhi = in.hwPhi; // @calo
+        out.hwZ0 = in.hwZ0;
+    }
+    inline void convert(const HadCaloObj & in, l1tpf_int::CaloCluster & out) {
+        out.hwPt = in.hwPt;
+        out.hwEmPt = in.hwEmPt;
+        out.hwEta = in.hwEta;
+        out.hwPhi = in.hwPhi;
+        out.isEM = in.hwIsEM;
+    }
+    inline void convert(const EmCaloObj & in, l1tpf_int::CaloCluster & out) {
+        out.hwPt = in.hwPt;
+        out.hwPtErr = in.hwPtErr;
+        out.hwEta = in.hwEta;
+        out.hwPhi = in.hwPhi;
+    }
+    inline void convert(const MuObj & in, l1tpf_int::Muon & out) {
+        out.hwPt = in.hwPt;
+        out.hwEta = in.hwEta; // @calo
+        out.hwPhi = in.hwPhi; // @calo
+    }
+
 
     template<unsigned int NMAX, typename In>
     void convert(const In in[NMAX], std::vector<l1tpf_int::PFParticle> &out) {

--- a/NtupleProducer/src/Firmware2DiscretePF.h
+++ b/NtupleProducer/src/Firmware2DiscretePF.h
@@ -20,9 +20,9 @@ namespace fw2dpf {
         pf.track = track; // FIXME: ok only as long as there is a 1-1 mapping
         pf.cluster.hwPt = 0;
         switch(src.hwId) {
-            case PID_Electron: pf.hwId =  l1tpf::Particle::EL; break;
-            case PID_Muon: pf.hwId =  l1tpf::Particle::MU; break;
-            default: pf.hwId =  l1tpf::Particle::CH; break;
+            case PID_Electron: pf.hwId =  1; break;
+            case PID_Muon: pf.hwId =  4; break;
+            default: pf.hwId = 0; break;
         };
         pf.hwStatus = 0;
         out.push_back(pf);
@@ -37,8 +37,8 @@ namespace fw2dpf {
         pf.track.hwPt = 0;
         pf.cluster.hwPt = src.hwPt;
         switch(src.hwId) {
-            case PID_Photon: pf.hwId = l1tpf::Particle::GAMMA; break;
-            default: pf.hwId = l1tpf::Particle::NH; break;
+            case PID_Photon: pf.hwId = 3; break;
+            default: pf.hwId = 2; break;
         }
         pf.hwStatus = 0;
         out.push_back(pf);

--- a/NtupleProducer/src/firmware/data.h
+++ b/NtupleProducer/src/firmware/data.h
@@ -4,7 +4,7 @@
 #include "ap_int.h"
 
 typedef ap_int<16> pt_t;
-typedef ap_int<9>  etaphi_t;
+typedef ap_int<10>  etaphi_t;
 typedef ap_int<5>  vtx_t;
 typedef ap_uint<3>  particleid_t;
 typedef ap_int<10> z0_t;  // 40cm / 0.1

--- a/NtupleProducer/src/firmware/data.h
+++ b/NtupleProducer/src/firmware/data.h
@@ -47,19 +47,37 @@ struct HadCaloObj : public CaloObj {
 	pt_t hwEmPt;
    	bool hwIsEM;
 };
+inline void clear(HadCaloObj & c) {
+    c.hwPt = 0; c.hwEta = 0; c.hwPhi = 0; c.hwEmPt = 0; c.hwIsEM = 0; 
+}
+
 struct EmCaloObj {
 	pt_t hwPt, hwPtErr;
 	etaphi_t hwEta, hwPhi; // relative to the region center, at calo
 };
+inline void clear(EmCaloObj & c) {
+    c.hwPt = 0; c.hwPtErr = 0; c.hwEta = 0; c.hwPhi = 0; 
+}
+
 struct TkObj {
 	pt_t hwPt, hwPtErr;
 	etaphi_t hwEta, hwPhi; // relative to the region center, at calo
 	z0_t hwZ0;
+        bool hwTightQuality;
 };
+inline void clear(TkObj & c) {
+    c.hwPt = 0; c.hwPtErr = 0; c.hwEta = 0; c.hwPhi = 0; c.hwZ0 = 0; c.hwTightQuality = 0;
+}
+
 struct MuObj {
 	pt_t hwPt, hwPtErr;
 	etaphi_t hwEta, hwPhi; // relative to the region center, at vtx(?)
 };
+inline void clear(MuObj & c) {
+    c.hwPt = 0; c.hwPtErr = 0; c.hwEta = 0; c.hwPhi = 0; 
+}
+
+
 struct PFChargedObj {
 	pt_t hwPt;
 	etaphi_t hwEta, hwPhi; // relative to the region center, at calo

--- a/NtupleProducer/src/firmware/data.h
+++ b/NtupleProducer/src/firmware/data.h
@@ -27,12 +27,12 @@ enum PID { PID_Charged=0, PID_Neutral=1, PID_Photon=2, PID_Electron=3, PID_Muon=
    #define NPHOTON NEMCALO
    #define NSELCALO 4
 #else
-   #define NTRACK 15
-   #define NCALO 15
-   #define NMU 4
-   #define NEMCALO 15
+   #define NTRACK 50
+   #define NCALO 50
+   #define NMU 8
+   #define NEMCALO 50
    #define NPHOTON NEMCALO
-   #define NSELCALO 10
+   #define NSELCALO 50
 #endif
 
 // PUPPI & CHS

--- a/NtupleProducer/src/firmware/simple_fullpfalgo.h
+++ b/NtupleProducer/src/firmware/simple_fullpfalgo.h
@@ -9,6 +9,7 @@ int dr2_int(etaphi_t eta1, etaphi_t phi1, etaphi_t eta2, etaphi_t phi2) ;
 template<int NB> ap_uint<NB>  dr2_int_cap(etaphi_t eta1, etaphi_t phi1, etaphi_t eta2, etaphi_t phi2, ap_uint<NB> max) ;
 
 void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], MuObj mu[NMU], PFChargedObj outch[NTRACK], PFNeutralObj outpho[NPHOTON], PFNeutralObj outne[NSELCALO], PFChargedObj outmu[NMU]) ;
+void pfalgo3_full_ref_set_debug(bool debug);
 void pfalgo3_full(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], MuObj mu[NMU], PFChargedObj outch[NTRACK], PFNeutralObj outpho[NPHOTON], PFNeutralObj outne[NSELCALO], PFChargedObj outmu[NMU]) ;
 void mp7wrapped_pack_in(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], MuObj mu[NMU], MP7DataWord data[MP7_NCHANN]) ;
 void mp7wrapped_unpack_in(MP7DataWord data[MP7_NCHANN], EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], MuObj mu[NMU]) ;

--- a/NtupleProducer/src/firmware/simple_fullpfalgo.h
+++ b/NtupleProducer/src/firmware/simple_fullpfalgo.h
@@ -21,6 +21,7 @@ void mp7wrapped_pfalgo3_full(MP7DataWord input[MP7_NCHANN], MP7DataWord output[M
 #define PFALGO3_DR2MAX_EM_CALO 525
 #define PFALGO3_DR2MAX_TK_MU   2101
 #define PFALGO3_DR2MAX_TK_EM   84
-#define PFALGO3_TK_MAXINVPT    80
+#define PFALGO3_TK_MAXINVPT_LOOSE    40
+#define PFALGO3_TK_MAXINVPT_TIGHT    80
 
 #endif

--- a/NtupleProducer/src/simple_fullpfalgo_ref.cpp
+++ b/NtupleProducer/src/simple_fullpfalgo_ref.cpp
@@ -5,7 +5,9 @@
 #include <cmath>
 #include <algorithm>
 
-bool g_debug_ = 0;
+bool g_debug_ = 1;
+
+void pfalgo3_full_ref_set_debug(bool debug) { g_debug_ = debug; }
 
 template <typename T> int sqr(const T & t) { return t*t; }
 

--- a/NtupleProducer/src/simple_fullpfalgo_ref.cpp
+++ b/NtupleProducer/src/simple_fullpfalgo_ref.cpp
@@ -1,7 +1,11 @@
 #include "firmware/data.h"
 #include "firmware/simple_fullpfalgo.h"
+#include "../interface/DiscretePFInputs.h"
+#include "Firmware2DiscretePF.h"
 #include <cmath>
 #include <algorithm>
+
+bool g_debug_ = 0;
 
 template <typename T> int sqr(const T & t) { return t*t; }
 
@@ -75,76 +79,6 @@ void ptsort_ref(T in[NIn], T out[NOut]) {
 }
 
 
-void pfalgo3_calo_ref(HadCaloObj calo[NCALO], TkObj track[NTRACK], PFChargedObj outch[NTRACK], PFNeutralObj outne[NCALO]) {
-    // constants
-    const pt_t     TKPT_MAX = PFALGO3_TK_MAXINVPT; // 20 * PT_SCALE;
-    const int      DR2MAX   = PFALGO3_DR2MAX_TK_CALO;
-
-    // initialize sum track pt
-    pt_t calo_sumtk[NCALO], calo_subpt[NCALO];
-    int  calo_sumtkErr2[NCALO];
-    for (int ic = 0; ic < NCALO; ++ic) { calo_sumtk[ic] = 0;  calo_sumtkErr2[ic] = 0;}
-
-    // initialize good track bit
-    bool track_good[NTRACK];
-    for (int it = 0; it < NTRACK; ++it) { track_good[it] = (track[it].hwPt < TKPT_MAX); }
-
-    // initialize output
-    for (int ipf = 0; ipf < NTRACK; ++ipf) { outch[ipf].hwPt = 0; }
-    for (int ipf = 0; ipf < NSELCALO; ++ipf) { outne[ipf].hwPt = 0; }
-
-    // for each track, find the closest calo
-    for (int it = 0; it < NTRACK; ++it) {
-        if (track[it].hwPt > 0) {
-            //int  ibest = best_match_ref<NCALO,DR2MAX,true,HadCaloObj>(calo, track[it]);
-            int  ibest = best_match_with_pt_ref<NCALO,DR2MAX,HadCaloObj>(calo, track[it]);
-            if (ibest != -1) {
-                track_good[it] = 1;
-                calo_sumtk[ibest]    += track[it].hwPt;
-                calo_sumtkErr2[ibest] += sqr(track[it].hwPtErr);
-            }
-        }
-    }
-
-    for (int ic = 0; ic < NCALO; ++ic) {
-        if (calo_sumtk[ic] > 0) {
-            pt_t ptdiff = calo[ic].hwPt - calo_sumtk[ic];
-            if (ptdiff > 0 && ptdiff*ptdiff > 4*calo_sumtkErr2[ic]) {
-                calo_subpt[ic] = ptdiff;
-            } else {
-                calo_subpt[ic] = 0;
-            }
-        } else {
-            calo_subpt[ic] = calo[ic].hwPt;
-        }
-    }
-
-    // copy out charged hadrons
-    for (int it = 0; it < NTRACK; ++it) {
-        if (track_good[it]) {
-            outch[it].hwPt = track[it].hwPt;
-            outch[it].hwEta = track[it].hwEta;
-            outch[it].hwPhi = track[it].hwPhi;
-            outch[it].hwZ0 = track[it].hwZ0;
-            outch[it].hwId  = PID_Charged;
-        }
-    }
-
-    // copy out neutral hadrons
-    PFNeutralObj outne_all[NCALO];
-    for (int ipf = 0; ipf < NCALO; ++ipf) { outne_all[ipf].hwPt = 0; }
-    for (int ic = 0; ic < NCALO; ++ic) {
-        if (calo_subpt[ic] > 0) {
-            outne_all[ic].hwPt  = calo_subpt[ic];
-            outne_all[ic].hwEta = calo[ic].hwEta;
-            outne_all[ic].hwPhi = calo[ic].hwPhi;
-            outne_all[ic].hwId  = PID_Neutral;
-        }
-    }
-
-    ptsort_ref<PFNeutralObj,NCALO,NSELCALO>(outne_all, outne);
-}
-
 void pfalgo3_em_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], bool isEle[NTRACK], bool isMu[NTRACK], PFNeutralObj outpho[NPHOTON], HadCaloObj hadcalo_out[NCALO]) {
     // constants
     const int DR2MAX_TE = PFALGO3_DR2MAX_TK_EM;
@@ -159,17 +93,18 @@ void pfalgo3_em_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj 
     for (int it = 0; it < NTRACK; ++it) {
         if (track[it].hwPt > 0 && !isMu[it]) {
             tk2em[it] = best_match_ref<NEMCALO,DR2MAX_TE,false,EmCaloObj>(emcalo, track[it]);
-            // printf("C++: tk not 0 index = %i and matched calo index = %i \n", it, int(tk2em[it]) );
             if (tk2em[it] != -1) {
+                if (g_debug_) printf("FW  \t track  %3d pt %7d matched to em calo %3d pt %7d\n", it, int(track[it].hwPt), tk2em[it], int(emcalo[tk2em[it]].hwPt));
                 calo_sumtk[tk2em[it]] += track[it].hwPt;
             }
         } else {
         	tk2em[it] = -1;
         }
-        // printf("C++: tk index = %i and match = %i and sumtk = %i \n", it, int(tk2em[it]), int(calo_sumtk[tk2em[it]]));        
     }
 
-    // for (int ic = 0; ic < NEMCALO; ++ic) {  printf("C++: calo_sumtk[NEMCALO] = %i \n", int(calo_sumtk[ic])); }
+    if (g_debug_) {
+        for (int ic = 0; ic < NEMCALO; ++ic) {  if (emcalo[ic].hwPt > 0) printf("FW  \t emcalo %3d pt %7d has sumtk %7d\n", ic, int(emcalo[ic].hwPt), int(calo_sumtk[ic])); }
+    }
 
     for (int ic = 0; ic < NEMCALO; ++ic) {
         pt_t photonPt;
@@ -179,35 +114,44 @@ void pfalgo3_em_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj 
                 // electron
                 photonPt = 0; 
                 isEM[ic] = true;
+                if (g_debug_) printf("FW  \t emcalo %3d pt %7d flagged as electron\n", ic, int(emcalo[ic].hwPt));
             } else if (ptdiff > 0) {
                 // electron + photon
                 photonPt = ptdiff; 
                 isEM[ic] = true;
+                if (g_debug_) printf("FW  \t emcalo %3d pt %7d flagged as electron + photon of pt %7d\n", ic, int(emcalo[ic].hwPt), int(photonPt));
             } else {
                 // pion
                 photonPt = 0;
                 isEM[ic] = false;
+                if (g_debug_) printf("FW  \t emcalo %3d pt %7d flagged as pion\n", ic, int(emcalo[ic].hwPt));
             }
         } else {
             // photon
             isEM[ic] = true;
             photonPt = emcalo[ic].hwPt;
+            if (g_debug_ && emcalo[ic].hwPt > 0) printf("FW  \t emcalo %3d pt %7d flagged as photon\n", ic, int(emcalo[ic].hwPt));
         }
         outpho[ic].hwPt  = photonPt;
         outpho[ic].hwEta = photonPt ? emcalo[ic].hwEta : etaphi_t(0);
         outpho[ic].hwPhi = photonPt ? emcalo[ic].hwPhi : etaphi_t(0);
         outpho[ic].hwId  = photonPt ? PID_Photon : particleid_t(0);
 
-        // printf("C++: emcalo index = %i and pt = %i and calo_sumtk = %i \n", ic, int(photonPt),int(calo_sumtk[ic]));
     }
 
     for (int it = 0; it < NTRACK; ++it) {
         isEle[it] = (tk2em[it] != -1) && isEM[tk2em[it]];
+        if (g_debug_ && isEle[it]) printf("FW  \t track  %3d pt %7d flagged as electron.\n", it, int(track[it].hwPt));
     }
 
     int em2calo[NEMCALO];
     for (int ic = 0; ic < NEMCALO; ++ic) {
         em2calo[ic] = best_match_ref<NCALO,DR2MAX_EH>(hadcalo, emcalo[ic]);
+        if (g_debug_ && (emcalo[ic].hwPt > 0)) {
+             printf("FW  \t emcalo %3d pt %7d isEM %d matched to hadcalo %7d pt %7d emPt %7d isEM %d\n", 
+                                ic, int(emcalo[ic].hwPt), isEM[ic], em2calo[ic], (em2calo[ic] >= 0 ? int(hadcalo[em2calo[ic]].hwPt) : -1), 
+                                (em2calo[ic] >= 0 ? int(hadcalo[em2calo[ic]].hwEmPt) : -1), (em2calo[ic] >= 0 ? int(hadcalo[em2calo[ic]].hwIsEM) : 0));
+        }
     }
     
     for (int ih = 0; ih < NCALO; ++ih) {
@@ -220,12 +164,19 @@ void pfalgo3_em_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj 
         }
         pt_t emdiff  = hadcalo[ih].hwEmPt - sub;
         pt_t alldiff = hadcalo[ih].hwPt - sub;
+        if (g_debug_ && (hadcalo[ih].hwPt > 0)) {
+            printf("FW  \t calo   %3d pt %7d has a subtracted pt of %7d, empt %7d -> %7d\n",
+                        ih, int(hadcalo[ih].hwPt), int(alldiff), int(hadcalo[ih].hwEmPt), int(emdiff));
+                    
+        }
         if (alldiff < ( hadcalo[ih].hwPt >>  4 ) ) {
             hadcalo_out[ih].hwPt = 0;   // kill
             hadcalo_out[ih].hwEmPt = 0; // kill
-        } else if (hadcalo[ih].hwIsEM && emdiff < ( hadcalo[ih].hwEmPt >> 3 ) ) {
+            if (g_debug_ && (hadcalo[ih].hwPt > 0)) printf("FW  \t calo   %3d pt %7d --> discarded (zero pt)\n", ih, int(hadcalo[ih].hwPt));
+        } else if ((hadcalo[ih].hwIsEM && emdiff < ( hadcalo[ih].hwEmPt >> 3 ))) {
             hadcalo_out[ih].hwPt = 0;   // kill
             hadcalo_out[ih].hwEmPt = 0; // kill
+            if (g_debug_ && (hadcalo[ih].hwPt > 0)) printf("FW  \t calo   %3d pt %7d --> discarded (zero em)\n", ih, int(hadcalo[ih].hwPt));
         } else {
             hadcalo_out[ih].hwPt   = alldiff;   
             hadcalo_out[ih].hwEmPt = (emdiff > 0 ? emdiff : pt_t(0)); 
@@ -234,6 +185,29 @@ void pfalgo3_em_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj 
 }
 
 void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], MuObj mu[NMU], PFChargedObj outch[NTRACK], PFNeutralObj outpho[NPHOTON], PFNeutralObj outne[NSELCALO], PFChargedObj outmu[NMU]) {
+
+    if (g_debug_) {
+        for (int i = 0; i < NTRACK; ++i) { if (track[i].hwPt == 0) continue;
+            l1tpf_int::PropagatedTrack tk; fw2dpf::convert(track[i], tk); 
+            printf("FW  \t track %3d: pt %8d [ %7.2f ]  calo eta %+7d [ %+5.2f ]  calo phi %+7d [ %+5.2f ]  calo ptErr %6d [ %7.2f ] \n", 
+                                i, tk.hwPt, tk.floatPt(), tk.hwEta, tk.floatEta(), tk.hwPhi, tk.floatPhi(), tk.hwCaloPtErr, tk.floatCaloPtErr());
+        }
+        for (int i = 0; i < NEMCALO; ++i) { if (emcalo[i].hwPt == 0) continue;
+            l1tpf_int::CaloCluster em; fw2dpf::convert(emcalo[i], em); 
+            printf("FW  \t EM    %3d: pt %8d [ %7.2f ]  calo eta %+7d [ %+5.2f ]  calo phi %+7d [ %+5.2f ]  calo ptErr %6d [ %7.2f ] \n", 
+                                i, em.hwPt, em.floatPt(), em.hwEta, em.floatEta(), em.hwPhi, em.floatPhi(), em.hwPtErr, em.floatPtErr());
+        } 
+        for (int i = 0; i < NCALO; ++i) { if (hadcalo[i].hwPt == 0) continue;
+            l1tpf_int::CaloCluster calo; fw2dpf::convert(hadcalo[i], calo); 
+            printf("FW  \t calo  %3d: pt %8d [ %7.2f ]  calo eta %+7d [ %+5.2f ]  calo phi %+7d [ %+5.2f ]  calo emPt %7d [ %7.2f ]   isEM %d \n", 
+                                i, calo.hwPt, calo.floatPt(), calo.hwEta, calo.floatEta(), calo.hwPhi, calo.floatPhi(), calo.hwEmPt, calo.floatEmPt(), calo.isEM);
+        } 
+        for (int i = 0; i < NMU; ++i) { if (mu[i].hwPt == 0) continue;
+            l1tpf_int::Muon muon; fw2dpf::convert(mu[i], muon); 
+            printf("FW  \t muon  %3d: pt %8d [ %7.2f ]  muon eta %+7d [ %+5.2f ]  muon phi %+7d [ %+5.2f ]   \n", 
+                                i, muon.hwPt, muon.floatPt(), muon.hwEta, muon.floatEta(), muon.hwPhi, muon.floatPhi());
+        } 
+    }
 
     // constants
     const pt_t     TKPT_MAX = PFALGO3_TK_MAXINVPT; // 20 * PT_SCALE;
@@ -270,6 +244,9 @@ void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkOb
                 outmu[im].hwId  = PID_Muon;
                 outmu[im].hwZ0 = track[ibest].hwZ0;      
                 isMu[ibest] = 1;
+                if (g_debug_) printf("FW  \t muon %3d linked to track %3d \n", im, ibest);
+            } else {
+                if (g_debug_) printf("FW  \t muon %3d not linked to any track\n", im);
             }
         }
     }
@@ -302,6 +279,7 @@ void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkOb
             int  ibest = best_match_with_pt_ref<NCALO,DR2MAX,HadCaloObj>(hadcalo_subem, track[it]);
             //int  ibest = best_match_ref<NCALO,DR2MAX,true,HadCaloObj>(hadcalo_subem, track[it]);
             if (ibest != -1) {
+                if (g_debug_) printf("FW  \t track  %3d pt %7d matched to calo' %3d pt %7d\n", it, int(track[it].hwPt), ibest, int(hadcalo_subem[ibest].hwPt));
                 track_good[it] = 1;
                 calo_sumtk[ibest]    += track[it].hwPt;
                 calo_sumtkErr2[ibest] += sqr(track[it].hwPtErr);
@@ -312,7 +290,15 @@ void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkOb
     for (int ic = 0; ic < NCALO; ++ic) {
         if (calo_sumtk[ic] > 0) {
             pt_t ptdiff = hadcalo_subem[ic].hwPt - calo_sumtk[ic];
-            if (ptdiff > 0 && ptdiff*ptdiff > 4*calo_sumtkErr2[ic]) {
+            int sigmamult = 4*calo_sumtkErr2[ic]; 
+            if (g_debug_ && (hadcalo_subem[ic].hwPt > 0)) {
+                l1tpf_int::CaloCluster floatcalo; fw2dpf::convert(hadcalo_subem[ic], floatcalo); 
+                printf("FW  \t calo'  %3d pt %7d [ %7.2f ] eta %+7d [ %+5.2f ] has a sum track pt %7d, difference %7d +- %.2f \n",
+                            ic, int(hadcalo_subem[ic].hwPt), floatcalo.floatPt(), int(hadcalo_subem[ic].hwEta), floatcalo.floatEta(), 
+                                int(calo_sumtk[ic]), int(ptdiff), std::sqrt(float(int(calo_sumtkErr2[ic]))));
+                        
+            }
+            if (ptdiff > 0 && ptdiff*ptdiff > sigmamult) {
                 calo_subpt[ic] = ptdiff;
             } else {
                 calo_subpt[ic] = 0;
@@ -320,6 +306,7 @@ void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkOb
         } else {
             calo_subpt[ic] = hadcalo_subem[ic].hwPt;
         }
+        if (g_debug_ && (hadcalo_subem[ic].hwPt > 0)) printf("FW  \t calo'  %3d pt %7d ---> %7d \n", ic, int(hadcalo_subem[ic].hwPt), int(calo_subpt[ic]));
     }
 
     // copy out charged hadrons

--- a/NtupleProducer/src/simple_fullpfalgo_ref.cpp
+++ b/NtupleProducer/src/simple_fullpfalgo_ref.cpp
@@ -112,21 +112,24 @@ void pfalgo3_em_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj 
         pt_t photonPt;
         if (calo_sumtk[ic] > 0) {
             pt_t ptdiff = emcalo[ic].hwPt - calo_sumtk[ic];
-            if (ptdiff*ptdiff <= 4*sqr(emcalo[ic].hwPtErr)) {
+            int sigma2 = sqr(emcalo[ic].hwPtErr);
+            int sigma2Lo = 4*sigma2, sigma2Hi = sigma2 + (sigma2>>1);
+            int ptdiff2 = ptdiff*ptdiff;
+            if ((ptdiff > 0 && ptdiff2 <= sigma2Hi) || (ptdiff < 0 && ptdiff2 < sigma2Lo)) {
                 // electron
                 photonPt = 0; 
                 isEM[ic] = true;
-                if (g_debug_) printf("FW  \t emcalo %3d pt %7d flagged as electron\n", ic, int(emcalo[ic].hwPt));
+                if (g_debug_) printf("FW  \t emcalo %3d pt %7d ptdiff %7d [match window: -%.2f / +%.2f] flagged as electron\n", ic, int(emcalo[ic].hwPt), int(ptdiff), std::sqrt(float(sigma2Lo)), std::sqrt(float(sigma2Hi)));
             } else if (ptdiff > 0) {
                 // electron + photon
                 photonPt = ptdiff; 
                 isEM[ic] = true;
-                if (g_debug_) printf("FW  \t emcalo %3d pt %7d flagged as electron + photon of pt %7d\n", ic, int(emcalo[ic].hwPt), int(photonPt));
+                if (g_debug_) printf("FW  \t emcalo %3d pt %7d ptdiff %7d [match window: -%.2f / +%.2f] flagged as electron + photon of pt %7d\n", ic, int(emcalo[ic].hwPt), int(ptdiff), std::sqrt(float(sigma2Lo)), std::sqrt(float(sigma2Hi)), int(photonPt));
             } else {
                 // pion
                 photonPt = 0;
                 isEM[ic] = false;
-                if (g_debug_) printf("FW  \t emcalo %3d pt %7d flagged as pion\n", ic, int(emcalo[ic].hwPt));
+                if (g_debug_) printf("FW  \t emcalo %3d pt %7d ptdiff %7d [match window: -%.2f / +%.2f] flagged as pion\n", ic, int(emcalo[ic].hwPt), int(ptdiff), std::sqrt(float(sigma2Lo)), std::sqrt(float(sigma2Hi)));
             }
         } else {
             // photon

--- a/NtupleProducer/src/simple_fullpfalgo_ref.cpp
+++ b/NtupleProducer/src/simple_fullpfalgo_ref.cpp
@@ -5,7 +5,7 @@
 #include <cmath>
 #include <algorithm>
 
-bool g_debug_ = 1;
+bool g_debug_ = 0;
 
 void pfalgo3_full_ref_set_debug(bool debug) { g_debug_ = debug; }
 
@@ -193,6 +193,7 @@ void pfalgo3_em_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj 
 void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj track[NTRACK], MuObj mu[NMU], PFChargedObj outch[NTRACK], PFNeutralObj outpho[NPHOTON], PFNeutralObj outne[NSELCALO], PFChargedObj outmu[NMU]) {
 
     if (g_debug_) {
+#ifdef FASTPUPPI_NTUPLERPRODUCER_DISCRETEPFINPUTS_MORE
         for (int i = 0; i < NTRACK; ++i) { if (track[i].hwPt == 0) continue;
             l1tpf_int::PropagatedTrack tk; fw2dpf::convert(track[i], tk); 
             printf("FW  \t track %3d: pt %8d [ %7.2f ]  calo eta %+7d [ %+5.2f ]  calo phi %+7d [ %+5.2f ]  calo ptErr %6d [ %7.2f ] \n", 
@@ -213,6 +214,7 @@ void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkOb
             printf("FW  \t muon  %3d: pt %8d [ %7.2f ]  muon eta %+7d [ %+5.2f ]  muon phi %+7d [ %+5.2f ]   \n", 
                                 i, muon.hwPt, muon.floatPt(), muon.hwEta, muon.floatEta(), muon.hwPhi, muon.floatPhi());
         } 
+#endif
     }
 
     // constants
@@ -305,10 +307,12 @@ void pfalgo3_full_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkOb
             pt_t ptdiff = hadcalo_subem[ic].hwPt - calo_sumtk[ic];
             int sigmamult = (calo_sumtkErr2[ic] + (calo_sumtkErr2[ic] >> 1)); // this multiplies by 1.5 = sqrt(1.5)^2 ~ (1.2)^2
             if (g_debug_ && (hadcalo_subem[ic].hwPt > 0)) {
+#ifdef FASTPUPPI_NTUPLERPRODUCER_DISCRETEPFINPUTS_MORE
                 l1tpf_int::CaloCluster floatcalo; fw2dpf::convert(hadcalo_subem[ic], floatcalo); 
                 printf("FW  \t calo'  %3d pt %7d [ %7.2f ] eta %+7d [ %+5.2f ] has a sum track pt %7d, difference %7d +- %.2f \n",
                             ic, int(hadcalo_subem[ic].hwPt), floatcalo.floatPt(), int(hadcalo_subem[ic].hwEta), floatcalo.floatEta(), 
                                 int(calo_sumtk[ic]), int(ptdiff), std::sqrt(float(int(calo_sumtkErr2[ic]))));
+#endif
                         
             }
             if (ptdiff > 0 && ptdiff*ptdiff > sigmamult) {

--- a/NtupleProducer/src/simple_fullpfalgo_ref.cpp
+++ b/NtupleProducer/src/simple_fullpfalgo_ref.cpp
@@ -168,15 +168,15 @@ void pfalgo3_em_ref(EmCaloObj emcalo[NEMCALO], HadCaloObj hadcalo[NCALO], TkObj 
         pt_t emdiff  = hadcalo[ih].hwEmPt - sub;
         pt_t alldiff = hadcalo[ih].hwPt - sub;
         if (g_debug_ && (hadcalo[ih].hwPt > 0)) {
-            printf("FW  \t calo   %3d pt %7d has a subtracted pt of %7d, empt %7d -> %7d\n",
-                        ih, int(hadcalo[ih].hwPt), int(alldiff), int(hadcalo[ih].hwEmPt), int(emdiff));
+            printf("FW  \t calo   %3d pt %7d has a subtracted pt of %7d, empt %7d -> %7d   isem %d keep %d \n",
+                        ih, int(hadcalo[ih].hwPt), int(alldiff), int(hadcalo[ih].hwEmPt), int(emdiff), int(hadcalo[ih].hwIsEM), keep);
                     
         }
-        if (alldiff < ( hadcalo[ih].hwPt >>  4 ) ) {
+        if (alldiff <= ( hadcalo[ih].hwPt >>  4 ) ) {
             hadcalo_out[ih].hwPt = 0;   // kill
             hadcalo_out[ih].hwEmPt = 0; // kill
             if (g_debug_ && (hadcalo[ih].hwPt > 0)) printf("FW  \t calo   %3d pt %7d --> discarded (zero pt)\n", ih, int(hadcalo[ih].hwPt));
-        } else if ((hadcalo[ih].hwIsEM && emdiff < ( hadcalo[ih].hwEmPt >> 3 )) && !keep) {
+        } else if ((hadcalo[ih].hwIsEM && emdiff <= ( hadcalo[ih].hwEmPt >> 3 )) && !keep) {
             hadcalo_out[ih].hwPt = 0;   // kill
             hadcalo_out[ih].hwEmPt = 0; // kill
             if (g_debug_ && (hadcalo[ih].hwPt > 0)) printf("FW  \t calo   %3d pt %7d --> discarded (zero em)\n", ih, int(hadcalo[ih].hwPt));


### PR DESCRIPTION
Better synchronization between CMSSW algo and firmware PF algo.
 * include in the firmware algo the refinements of https://github.com/gpetruc/GlobalCorrelator_HLS/pull/1 
  (will PR to the main repo once https://github.com/p2l1pfp/GlobalCorrelator_HLS/pull/17 is merged)
 * change the 1.2&sigma; in the linking to sqrt(1.5) &sigma;, which is easier to compute in firmware
 * fix some aspects of dealing with regions (consistency between at-vertex and at-calo-face coordinates, `<` vs `<=`, etc.)
 * add some switches to make the CMSSW more similar to the PF. 
        `process.InfoOut.linking.trackMuMatch = "drBestByPtDiff" `
        `process.InfoOut.linking.trackCaloLinkMetric = "bestByDR2Pt2"`
        `process.InfoOut.linking.emCaloUseAlsoCaloSigma = False`
        `process.InfoOut.linking.ecalPriority = False`
        `process.InfoOut.linking.trackEmUseAlsoTrackSigma = False` 
      * the first three should have negligible impact on the physics performance, so they could  become the new defaults, but I didn't test them at PU 140. 
      * for the ecal priority, the current CMSSW version is not firmware-friendly because it can create two neutral pf candidates from a single calo cluster, but I think it should be possible to implement one that just prefers to create a photon instead of a neutral hadron, which should recover most of what ecalPriority does (i.e. avoid creating a neutral hadron in cases where there's a charged hadron overlapping with a photon)
      * trackEmUseAlsoTrackSigma may have some impact on electron linking, but anyway probably the entire electron linking and id should be reoptimized as the current thing is very crude.
 * more debugging facilities
