### PR TITLE
Configurations to run with 3D clusters (FastPuppi part)

### DIFF
--- a/NtupleProducer/BuildFile.xml
+++ b/NtupleProducer/BuildFile.xml
@@ -6,6 +6,11 @@
 <use name="RecoMET/METAlgorithms"/>
 <use name="FastSimulation/BaseParticlePropagator"/>
 <use name="DataFormats/ParticleFlowReco"/>
+<use name="SimDataFormats/CaloAnalysis"/>
+<use name="DataFormats/L1THGCal"/>
+<use name="CommonTools/Utils"/>
+<use name="Geometry/Records"/>
+<use name="L1Trigger/L1THGCal"/>
 <use name="fastjet"/>
 <export>
   <lib name="1"/>

--- a/NtupleProducer/plugins/IDNTuplizer.cc
+++ b/NtupleProducer/plugins/IDNTuplizer.cc
@@ -1,0 +1,227 @@
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/View.h"
+
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "DataFormats/JetReco/interface/GenJet.h"
+
+#include "DataFormats/Math/interface/deltaR.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
+#include <FastPUPPI/NtupleProducer/interface/L1TPFUtils.h>
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "CommonTools/Utils/interface/StringObjectFunction.h"
+
+#include <cstdint>
+#include <TTree.h>
+
+class IDNTuplizer : public edm::one::EDAnalyzer<edm::one::SharedResources,edm::one::WatchRuns>  {
+    public:
+        explicit IDNTuplizer(const edm::ParameterSet&);
+        ~IDNTuplizer();
+
+    private:
+        virtual void beginJob() override;
+        virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+        virtual void beginRun(edm::Run const&, edm::EventSetup const& iSetup) override {
+            //edm::ESHandle<MagneticField> magneticField;
+            //iSetup.get<IdealMagneticFieldRecord>().get(magneticField);
+            //bZ_ = magneticField->inTesla(GlobalPoint(0,0,0)).z();
+            bZ_ = 3.8112; // avoid loading the event setup
+        }
+        virtual void endRun(edm::Run const&, edm::EventSetup const& iSetup) override { } // framework wants this to be implemented
+
+        edm::EDGetTokenT<reco::CandidateView> src_;
+        StringCutObjectSelector<reco::Candidate> sel_;
+        
+        edm::EDGetTokenT<std::vector<reco::GenParticle>> genparticles_;
+        bool prop_;
+        float dr2Max_, minPtRatio_;
+        bool onlyMatched_;
+        TTree *tree_;
+        uint32_t run_, lumi_; uint64_t event_;
+
+        struct McVars {
+            float pt, eta, phi, dr;
+            int   id;
+            void makeBranches(TTree *tree) {
+                tree->Branch("genid", &id, "genid/I");
+                tree->Branch("gendr", &dr, "gendr/F");
+                tree->Branch("genpt", &pt, "genpt/F");
+                tree->Branch("geneta", &eta, "geneta/F");
+                tree->Branch("genphi", &phi, "genphi/F");
+            }
+            void clear() {
+                pt = 0; eta = 0; phi = 0; dr = 0; id = 0;
+            }
+            void fill(const reco::GenParticle &c, bool propagate, float bz) {
+                id = c.pdgId();
+                pt = c.pt(); 
+                if (propagate && c.charge() != 0) {
+                    math::XYZTLorentzVector momentum(c.px(),c.py(),c.pz(),c.energy());
+                    math::XYZTLorentzVector vertex(c.vx(),c.vy(),c.vz(),0.);
+                    std::vector<double> lVars;
+                    l1tpf::propagate(1,lVars,momentum,vertex,c.charge(),bz);
+                    eta = lVars[4]; phi = lVars[5];
+                } else {
+                    eta = c.eta(); phi = c.phi();
+                }
+            }
+        } mc_;
+
+        class RecoVar {
+            public:
+                RecoVar(const std::string & name, const std::string & expr) : name_(name), expr_(expr,true) {}
+                void makeBranch(TTree *tree) {
+                    tree->Branch(name_.c_str(), &val_, (name_+"/F").c_str());
+                }
+                void fill(const reco::Candidate & c) {
+                    val_ = expr_(c);
+                }
+            private:
+                std::string name_;
+                StringObjectFunction<reco::Candidate> expr_;
+                float val_;
+        };
+        std::vector<RecoVar> reco_;
+
+        struct ExtVar { 
+                ExtVar(const std::string & name, edm::EDGetTokenT<edm::ValueMap<float>> token) : name_(name), token_(token) {}
+                void makeBranch(TTree *tree) {
+                    tree->Branch(name_.c_str(), &val_, (name_+"/F").c_str());
+                }
+                void init(const edm::Event & iEvent) {
+                    iEvent.getByToken(token_, handle_);
+                }
+                void fill(const reco::CandidatePtr & c) {
+                    val_ = (*handle_)[c];
+                }
+            private:
+                std::string name_;
+                edm::EDGetTokenT<edm::ValueMap<float>> token_;
+                edm::Handle<edm::ValueMap<float>> handle_;
+                float val_;
+        };
+        std::vector<ExtVar> ext_;
+
+        float bZ_;
+ 
+};
+
+IDNTuplizer::IDNTuplizer(const edm::ParameterSet& iConfig) :
+    src_(consumes<reco::CandidateView>(iConfig.getParameter<edm::InputTag>("src"))),
+    sel_(iConfig.getParameter<std::string>("cut"), true),
+    genparticles_(consumes<std::vector<reco::GenParticle>>(iConfig.getParameter<edm::InputTag>("genParticles"))),
+    prop_(iConfig.getParameter<bool>("propagateToCalo")),
+    dr2Max_(std::pow(iConfig.getParameter<double>("drMax"), 2)),
+    minPtRatio_(iConfig.getParameter<double>("minRecoPtOverGenPt")),
+    onlyMatched_(iConfig.getParameter<bool>("onlyMatched"))
+{
+    usesResource("TFileService");
+    edm::Service<TFileService> fs;
+    tree_ = fs->make<TTree>("tree","tree");
+    tree_->Branch("run",  &run_,  "run/i");
+    tree_->Branch("lumi", &lumi_, "lumi/i");
+    tree_->Branch("event", &event_, "event/l");
+
+    edm::ParameterSet vars = iConfig.getParameter<edm::ParameterSet>("variables");
+    auto reconames = vars.getParameterNamesForType<std::string>();
+    for (const std::string & name : reconames) {
+        reco_.emplace_back(name, vars.getParameter<std::string>(name));
+    }
+
+    if (iConfig.existsAs<edm::ParameterSet>("extVariables")) {
+        edm::ParameterSet evars = iConfig.getParameter<edm::ParameterSet>("extVariables");
+        auto enames = evars.getParameterNamesForType<edm::InputTag>();
+        for (const std::string & name : enames) {
+            ext_.emplace_back(name, consumes<edm::ValueMap<float>>(evars.getParameter<edm::InputTag>(name)));
+        }
+
+    }
+}
+
+IDNTuplizer::~IDNTuplizer() { }
+
+// ------------ method called once each job just before starting event loop  ------------
+    void 
+IDNTuplizer::beginJob()
+{
+    mc_.makeBranches(tree_);
+    for (auto & v : reco_) v.makeBranch(tree_);
+    for (auto & v : ext_) v.makeBranch(tree_);
+}
+
+
+// ------------ method called for each event  ------------
+    void
+IDNTuplizer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+    run_  = iEvent.id().run();
+    lumi_ = iEvent.id().luminosityBlock();
+    event_ = iEvent.id().event();
+
+    edm::Handle<std::vector<reco::GenParticle>> genparticles;
+    iEvent.getByToken(genparticles_, genparticles);
+
+    edm::Handle<reco::CandidateView> src;
+    iEvent.getByToken(src_, src);
+
+    for (auto & v : ext_) v.init(iEvent);
+
+    std::vector<reco::CandidatePtr> selected;
+    for (unsigned int i = 0, n = src->size(); i < n; ++i) {
+        const auto & c = (*src)[i];
+        if (sel_(c)) selected.push_back(src->ptrAt(i));
+    }
+
+    std::vector<bool> matched(selected.size(), 0);
+
+    for (const reco::GenParticle &gen : *genparticles) {
+        mc_.fill(gen, prop_, bZ_);
+        float dr2best = dr2Max_; int ibest = -1;
+        for (unsigned int ireco = 0, nreco = selected.size(); ireco < nreco; ++ireco) {
+            const reco::Candidate & reco = *(selected[ireco]);
+            if (reco.pt() <= minPtRatio_*gen.pt()) continue;
+            float dr2 = deltaR2(reco.eta(), reco.phi(), mc_.eta, mc_.phi);
+            if (dr2 < dr2best) { dr2best = dr2; ibest = ireco; }
+        }
+        if (ibest != -1) {
+            matched[ibest] = true;
+            mc_.dr = std::sqrt(dr2best);
+            const reco::CandidatePtr & reco = (selected[ibest]);
+            for (auto & v : reco_) v.fill(*reco);
+            for (auto & v : ext_) v.fill(reco);
+            tree_->Fill();
+        }
+    }
+    if (!onlyMatched_) {
+        mc_.clear();
+        for (unsigned int ireco = 0, nreco = selected.size(); ireco < nreco; ++ireco) {
+            if (matched[ireco]) continue;
+            const reco::CandidatePtr & reco = (selected[ireco]);
+            for (auto & v : reco_) v.fill(*reco);
+            for (auto & v : ext_) v.fill(reco);
+            tree_->Fill();
+        }
+    }
+}
+
+//define this as a plug-in
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(IDNTuplizer);

--- a/NtupleProducer/python/runIDNTuplerHGCTune.py
+++ b/NtupleProducer/python/runIDNTuplerHGCTune.py
@@ -1,0 +1,161 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
+
+process = cms.Process("ID", eras.Phase2_trigger)
+
+process.load('Configuration.StandardSequences.Services_cff')
+process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10))
+process.MessageLogger.cerr.FwkReport.reportEvery = 1
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring('file:inputs.root'),
+    duplicateCheckMode = cms.untracked.string("noDuplicateCheck")
+)
+
+process.load('Configuration.Geometry.GeometryExtended2023D17Reco_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '100X_upgrade2023_realistic_v1', '')
+
+process.load("L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff")
+process.hgcalConcentratorProducerSTC = process.hgcalConcentratorProducer.clone()
+process.hgcalConcentratorProducerSTC.ProcessorParameters.Method = 'superTriggerCellSelect'
+process.hgcalConcentratorProducerSTC.ProcessorParameters.triggercell_threshold_silicon = 0
+process.hgcalConcentratorProducerSTC.ProcessorParameters.TCThreshold_fC = 0
+
+process.hgcalBackEndLayer1ProducerSTC =  process.hgcalBackEndLayer1Producer.clone()
+process.hgcalBackEndLayer1ProducerSTC.InputTriggerCells = cms.InputTag("hgcalConcentratorProducerSTC","HGCalConcentratorProcessorSelection")
+process.hgcalBackEndLayer1ProducerSTC.ProcessorParameters.C2d_parameters.clusterType = cms.string('dummyC2d')
+process.hgcalBackEndLayer1ProducerSTC.ProcessorParameters.C2d_parameters.threshold_scintillator = cms.double(0)
+process.hgcalBackEndLayer1ProducerSTC.ProcessorParameters.C2d_parameters.threshold_silicon      = cms.double(0)
+
+process.hgcalBackEndLayer2ProducerSTC = process.hgcalBackEndLayer2Producer.clone()
+process.hgcalBackEndLayer2ProducerSTC.ProcessorParameters.C3d_parameters.dR_multicluster = 0.03
+process.hgcalBackEndLayer2ProducerSTC.ProcessorParameters.C3d_parameters.type_multicluster = 'HistoMaxC3d'
+process.hgcalBackEndLayer2ProducerSTC.ProcessorParameters.C3d_parameters.threshold_histo_multicluster = 20
+process.hgcalBackEndLayer2ProducerSTC.InputCluster = cms.InputTag("hgcalBackEndLayer1ProducerSTC","HGCalBackendLayer1Processor2DClustering")
+process.hgcalBackEndLayer2ProducerSTC.ProcessorParameters.C3d_parameters.dR_multicluster_byLayer = cms.vdouble(
+            [0] + [0.010]*7 + [0.020]*7 + [0.030]*7 + [0.040]*7 +   [0.040]*6 + [0.050]*6  +  [0.050]*12 )
+
+ntuple = cms.EDAnalyzer("IDNTuplizer",
+    src = cms.InputTag("FILLME"),
+    cut = cms.string("pt > 1"),
+    genParticles = cms.InputTag("genParticles"),
+    propagateToCalo = cms.bool(True),
+    drMax = cms.double(0.1),
+    minRecoPtOverGenPt = cms.double(0.3),
+    onlyMatched = cms.bool(True),
+    variables = cms.PSet(
+	pt = cms.string("pt"),
+	emPt = cms.string("? hOverE >= 0 ? pt/(1+hOverE) : 0"),
+ 	eta = cms.string("eta"),
+ 	phi = cms.string("phi"),
+ 	hOverE = cms.string("hOverE"),
+        emf = cms.string("? hOverE >= 0 ? 1/(1+hOverE) : 0"),
+ 	showerLength = cms.string("showerLength"),
+ 	coreShowerLength = cms.string("coreShowerLength"),
+ 	firstLayer = cms.string("firstLayer"),
+ 	maxLayer = cms.string("maxLayer"),
+ 	eMax = cms.string("eMax"),
+ 	eMaxOverE = cms.string("eMax/energy"),
+ 	sigmaEtaEtaMax = cms.string("sigmaEtaEtaMax"),
+ 	sigmaPhiPhiMax = cms.string("sigmaPhiPhiMax"),
+ 	sigmaEtaEtaTot = cms.string("sigmaEtaEtaTot"),
+ 	sigmaPhiPhiTot = cms.string("sigmaPhiPhiTot"),
+ 	sigmaZZ = cms.string("sigmaZZ"),
+ 	sigmaRRTot = cms.string("sigmaRRTot"),
+ 	sigmaRRMax = cms.string("sigmaRRMax"),
+ 	sigmaRRMean = cms.string("sigmaRRMean"),
+    ),
+)
+
+process.ntupleSTC = ntuple.clone( src = cms.InputTag("hgcalBackEndLayer2ProducerSTC","HGCalBackendLayer2Processor3DClustering") )
+  
+modules = [
+    # process.hgcalConcentratorProducerSTC, # already in the inputs
+    process.hgcalBackEndLayer1ProducerSTC,
+    process.hgcalBackEndLayer2ProducerSTC,
+    process.ntupleSTC
+]
+
+def newClustering(postfix,
+        concentratorAlgo="thresholdSelect", # 'thresholdSelect' or 'superTriggerCellSelect'
+        concentratorThreshold=2,
+        layer1Algo="dummyC2d",
+        layer1Threshold=0,
+        layer2Algo="HistoMaxC3d",
+        layer2Threshold=0,
+        layer2dR=0.03,
+        reuseConc=None, reuseL1=None):
+    global modules
+    if reuseConc is None:
+        conc = process.hgcalConcentratorProducer.clone()
+        conc.ProcessorParameters.Method = concentratorAlgo
+        conc.ProcessorParameters.triggercell_threshold_silicon = concentratorThreshold
+        if concentratorThreshold == 0: conc.ProcessorParameters.TCThreshold_fC = 0
+        setattr(process, "hgcalConcentratorProducer"+postfix, conc)
+        reuseConc = postfix
+        modules.append(conc)
+    #
+    if reuseL1 is None:
+        bel1 = process.hgcalBackEndLayer1Producer.clone()
+        bel1.InputTriggerCells = cms.InputTag("hgcalConcentratorProducer"+reuseConc,"HGCalConcentratorProcessorSelection")
+        bel1.ProcessorParameters.C2d_parameters.clusterType = cms.string(layer1Algo)
+        bel1.ProcessorParameters.C2d_parameters.threshold_scintillator = cms.double(layer1Threshold)
+        bel1.ProcessorParameters.C2d_parameters.threshold_silicon      = cms.double(layer1Threshold)
+        setattr(process, "hgcalBackEndLayer1Producer"+postfix, bel1)
+        modules.append(bel1)
+        reuseL1 = postfix
+    #
+    bel2 = process.hgcalBackEndLayer2Producer.clone()
+    bel2.InputCluster = cms.InputTag("hgcalBackEndLayer1Producer"+reuseL1,"HGCalBackendLayer1Processor2DClustering")
+    bel2.ProcessorParameters.C3d_parameters.type_multicluster = layer2Algo
+    bel2.ProcessorParameters.C3d_parameters.threshold_histo_multicluster = layer2Threshold
+    if type(layer2dR) == list:
+        bel2.ProcessorParameters.C3d_parameters.dR_multicluster_byLayer = cms.vdouble(layer2dR)
+        bel2.ProcessorParameters.C3d_parameters.dR_multicluster = 0.03 if type(layer2dR) == list else layer2dR
+    else:
+        bel2.ProcessorParameters.C3d_parameters.dR_multicluster = 0.03 if type(layer2dR) == list else layer2dR
+    setattr(process, "hgcalBackEndLayer2Producer"+postfix, bel2)
+    modules.append(bel2)
+    #
+    nt = ntuple.clone()
+    nt.src = cms.InputTag("hgcalBackEndLayer2Producer"+postfix,"HGCalBackendLayer2Processor3DClustering")
+    setattr(process, "ntuple"+postfix, nt)
+    modules.append(nt)
+
+
+newClustering("STCdR03", reuseConc="STC", reuseL1="STC", layer2Threshold=20, layer2dR = 0.03)
+
+#newClustering("STC070", concentratorAlgo="superTriggerCellSelect", concentratorThreshold=0.7, layer1Threshold=0, layer2Threshold=20, 
+#                    layer2dR = ([0] + [0.010]*7 + [0.020]*7 + [0.030]*7 + [0.040]*7 +   [0.040]*6 + [0.050]*6  +  [0.050]*12))
+#newClustering("STC073",  reuseConc="STC070", layer1Threshold=3, layer2Threshold=20, 
+#                    layer2dR = ([0] + [0.010]*7 + [0.020]*7 + [0.030]*7 + [0.040]*7 +   [0.040]*6 + [0.050]*6  +  [0.050]*12))
+newClustering("TC", reuseConc="", layer1Threshold=0, layer2Threshold=20, layer2dR = ([0] + [0.010]*7 + [0.020]*7 + [0.030]*7 + [0.040]*7 +   [0.040]*6 + [0.050]*6  +  [0.050]*12))
+newClustering("TCdR03", reuseConc="", reuseL1="TC", layer2Threshold=20, layer2dR = 0.03)
+
+process.p = cms.Path(sum(modules[1:], modules[0]))
+process.TFileService = cms.Service("TFileService", fileName = cms.string("idTupleNew.root"))
+
+def goRandom():
+    for aname in process.analyzers_().keys():
+        if aname.startswith("ntuple"):
+            ana = getattr(process,aname)
+            if hasattr(ana, 'onlyMatched'):
+                ana.onlyMatched = False
+def hgcAcc(pdgId,ptmin=2):
+    process.acceptance = cms.EDFilter("GenParticleSelector",
+        src = cms.InputTag("genParticles"),
+        cut = cms.string("abs(pdgId) == %d && pt > %g && abs(eta) > 1.6 && abs(eta) < 2.6" % (pdgId,ptmin)),
+        filter = cms.bool(True),
+    )
+    process.p.insert(0, process.acceptance)
+def xdup():
+    process.options.numberOfThreads = cms.untracked.uint32(2)
+    process.options.numberOfStreams = cms.untracked.uint32(0)
+

--- a/NtupleProducer/python/runNewInputs.py
+++ b/NtupleProducer/python/runNewInputs.py
@@ -16,13 +16,14 @@ process.load('Configuration.StandardSequences.SimL1Emulator_cff')
 process.load('L1Trigger.TrackFindingTracklet.L1TrackletTracks_cff')
 process.VertexProducer.l1TracksInputTag = cms.InputTag("TTTracksFromTracklet", "Level1TTTracks")
 
+process.load('L1Trigger.Phase2L1ParticleFlow.hgc3dClustersForPF_cff')
+
 process.source = cms.Source("PoolSource",
-    #fileNames = cms.untracked.vstring('file:/eos/cms/store/relval/CMSSW_9_3_7/RelValSingleTauFlatPt2To100_pythia8/GEN-SIM-DIGI-RAW/93X_upgrade2023_realistic_v5_2023D17noPU-v2/10000/58739462-8B2C-E811-A013-0CC47A7C34D0.root'),
-    #fileNames = cms.untracked.vstring('file:/eos/cms/store/relval/CMSSW_9_3_7/RelValZMM_14/GEN-SIM-DIGI-RAW/93X_upgrade2023_realistic_v5_2023D17noPU-v1/10000/96D02123-012D-E811-868C-0CC47A4D7640.root'),
-    fileNames = cms.untracked.vstring('/store/relval/CMSSW_9_3_7/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/93X_upgrade2023_realistic_v5_2023D17noPU-v2/10000/7EC7DD7F-782C-E811-B469-0CC47A4D76A0.root'),
+    fileNames = cms.untracked.vstring('file:/eos/cms/store/cmst3/group/l1tr/gpetrucc/93X/HadronGun/GEN-SIM-DIGI-RAW/HadronGun_job1_sub1.GEN-SIM-DIGI-RAW.root'),
     duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
     inputCommands = cms.untracked.vstring("keep *", 
         "drop l1tHGCalTowerMapBXVector_hgcalTriggerPrimitiveDigiProducer_towerMap_HLT",
+        "drop *_hgcalTriggerPrimitiveDigiProducer_*_*",
         "drop l1tEMTFHit2016Extras_simEmtfDigis_CSC_HLT",
         "drop l1tEMTFHit2016Extras_simEmtfDigis_RPC_HLT",
         "drop l1tEMTFHit2016s_simEmtfDigis__HLT",
@@ -35,7 +36,10 @@ process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
   
 
 process.p = cms.Path(
-    process.L1TrackletTracks + process.SimL1Emulator
+    process.L1TrackletTracks +
+    process.SimL1Emulator +
+    process.hgc3dClustersForPF_STC +
+    process.hgc3dClustersForPF_TC
 )
 
 process.out = cms.OutputModule("PoolOutputModule",
@@ -47,15 +51,20 @@ process.out = cms.OutputModule("PoolOutputModule",
             "keep *_genMetTrue_*_*",
             # --- PF IN
             "keep *_TTTracksFromTracklet_Level1TTTracks_*",
+            # ecal
             "keep *_l1EGammaCrystalsProducer_L1EGXtalClusterNoCuts_*",
-            "keep *_hgcalTriggerPrimitiveDigiProducer_cluster3D_IN",
-            "keep *_hgcalTriggerPrimitiveDigiProducer_cluster2D_IN",
-            "keep *_hgcalTriggerPrimitiveDigiProducer_calibratedTriggerCells_IN",
+            "keep *_l1EGammaCrystalsProducer_*_*",
+            # HGC
+            #"keep *_hgcalVFEProducer_*_IN", # uncomment to be able to re-run the concentrator
+            "keep *_hgcalConcentratorProducer*_*_IN",
+            "keep *_hgcalBackEndLayer1Producer*_*_IN",
+            "keep *_hgcalBackEndLayer2Producer*_*_IN",
+            "keep *_hgcalTowerMapProducer_*_IN",
+            "keep *_hgcalTowerProducer_*_IN",
+            # muons
             "keep *_simGmtStage2Digis__*",
+            # hcal
             "keep *_simHcalTriggerPrimitiveDigis__*",
-            # --- to be tested
-            "keep *_hgcalTriggerPrimitiveDigiProducer_tower_IN",
-            "keep *_hgcalTriggerPrimitiveDigiProducer_towerMap_IN",
             # --- Stage2 ---
             "keep *_simCaloStage2Digis_*_*",
             # --- TK IN
@@ -72,6 +81,8 @@ process.out = cms.OutputModule("PoolOutputModule",
             "keep *_L1TrackerHTMiss_*_*",
             "keep *_L1TrackerJets_*_*",
             "keep *_VertexProducer_*_*",
+            "keep *_l1KBmtfStubMatchedMuons_*_*",
+            "keep *_l1EGammaEEProducer_*_*",
             # --- PF OUT
             "keep l1tPFClusters_*_*_*",
             "keep l1tPFTracks_*_*_*",
@@ -83,6 +94,7 @@ process.out = cms.OutputModule("PoolOutputModule",
         fastCloning = cms.untracked.bool(False),
         overrideInputFileSplitLevels = cms.untracked.bool(True),
         eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
+        SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("p")),
 )
 process.e = cms.EndPath(process.out)
 

--- a/NtupleProducer/python/runRespNTuplerNew.py
+++ b/NtupleProducer/python/runRespNTuplerNew.py
@@ -177,7 +177,7 @@ def hgcAcc(pdgId,pt=10,eta=(1.6,2.6),prompt=False):
     pdgIdCut = "||".join("abs(pdgId) == %d" % p for p in pdgId)
     process.acceptance = cms.EDFilter("GenParticleSelector",
         src = cms.InputTag("genParticles"),
-        cut = cms.string("(%s) && pt > %g && %g < abs(eta) && abs(eta) < %g%s" % (pdgIdCut, pt, eta[0], eta[1], "&& isPrompt" if prompt else "")),
+        cut = cms.string("(%s) && pt > %g && %g < abs(eta) && abs(eta) < %g%s" % (pdgIdCut, pt, eta[0], eta[1], "&& statusFlags.isPrompt" if prompt else "")),
         filter = cms.bool(True),
     )
     process.p.insert(0, process.acceptance)

--- a/NtupleProducer/python/runRespNTuplerNew3D.py
+++ b/NtupleProducer/python/runRespNTuplerNew3D.py
@@ -7,7 +7,7 @@ process.load('Configuration.StandardSequences.Services_cff')
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True), allowUnscheduled = cms.untracked.bool(False) )
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10))
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1))
 process.MessageLogger.cerr.FwkReport.reportEvery = 1
 
 process.source = cms.Source("PoolSource",
@@ -102,6 +102,10 @@ if True:
     process.ntuple.objects.L1PFCharged_sel = cms.string("charge != 0")
     process.ntuple.objects.L1PFPhoton = cms.VInputTag("l1pfCandidates:PF",)
     process.ntuple.objects.L1PFPhoton_sel = cms.string("pdgId == 22")
+    process.ntuple.objects.L1PFMuon = cms.VInputTag("l1pfCandidates:PF",)
+    process.ntuple.objects.L1PFMuon_sel = cms.string("abs(pdgId) == 13")
+    process.ntuple.objects.L1PFElectron = cms.VInputTag("l1pfCandidates:PF",)
+    process.ntuple.objects.L1PFElectron_sel = cms.string("abs(pdgId) == 11")
     process.ntuple.objects.L1PuppiCharged = cms.VInputTag("l1pfCandidates:Puppi",)
     process.ntuple.objects.L1PuppiCharged_sel = cms.string("charge != 0")
     process.ntuple.objects.L1PuppiPhoton = cms.VInputTag("l1pfCandidates:Puppi",)
@@ -142,7 +146,7 @@ def hgcAcc(pdgId,pt=10,eta=(1.6,2.6),prompt=False):
     pdgIdCut = "||".join("abs(pdgId) == %d" % p for p in pdgId)
     process.acceptance = cms.EDFilter("GenParticleSelector",
         src = cms.InputTag("genParticles"),
-        cut = cms.string("(%s) && pt > %g && %g < abs(eta) && abs(eta) < %g%s" % (pdgIdCut, pt, eta[0], eta[1], "&& isPrompt" if prompt else "")),
+        cut = cms.string("(%s) && pt > %g && %g < abs(eta) && abs(eta) < %g%s" % (pdgIdCut, pt, eta[0], eta[1], "&& statusFlags.isPrompt" if prompt else "")),
         filter = cms.bool(True),
     )
     process.p.insert(0, process.acceptance)

--- a/NtupleProducer/python/scripts/prun.sh
+++ b/NtupleProducer/python/scripts/prun.sh
@@ -1,8 +1,12 @@
 CODE=${1/.py/}; shift
-#MAIN=/eos/cms/store/cmst3/user/jngadiub/L1PFInputs/$1/
-#MAIN=/eos/cms/store/cmst3/user/gpetrucc/l1phase2/93X/Inputs/$1/
-MAIN=/eos/cms/store/cmst3/group/l1tr/gpetrucc/101X/NewInputs/080818/$1
+MAIN=/eos/cms/store/cmst3/group/l1tr/gpetrucc/101X/NewInputs/231018/$1
 PREFIX="inputs_"
+
+if [[ "$1" == "--3D" ]]; then
+    shift;
+    MAIN=/eos/cms/store/cmst3/group/l1tr/gpetrucc/101X/NewInputs/011118/$1
+    PREFIX="reinputs_"
+fi;
 
 INPUT=$1; shift
 if [[ "$1" != "" ]]; then
@@ -12,18 +16,14 @@ else
     OUTPUT="${INPUT}";
 fi;
 
-if [[ "$1" == "--92X" ]]; then
-    MAIN=/eos/cms/store/cmst3/user/jngadiub/L1PFInputs/$INPUT/
-    shift;
-fi;
 clean=true
 if [[ "$1" == "--noclean" ]]; then
     clean=false;
     shift
 fi
 
-#~gpetrucc/pl/cmsSplit.pl --files "$MAIN/${INPUT}/inputs_17D*root" --label ${OUTPUT} ${CODE}.py --bash --n 8 $* && bash ${CODE}_${OUTPUT}_local.sh && bash ${CODE}_${OUTPUT}_cleanup.sh
-python/scripts/cmsSplit.pl --files "$MAIN/${PREFIX}*${INPUT}*root" --label ${OUTPUT} ${CODE}.py --bash --n 8 $* && bash ${CODE}_${OUTPUT}_local.sh 
+PSCRIPT=$CMSSW_BASE/src/FastPUPPI/NtupleProducer/python/scripts/
+$PSCRIPT/cmsSplit.pl --files "$MAIN/${PREFIX}*${INPUT}*root" --label ${OUTPUT} ${CODE}.py --bash --n 8 $* && bash ${CODE}_${OUTPUT}_local.sh 
 
 if $clean; then
     REPORT=$(grep -o "tee \S\+_${OUTPUT}.report.txt" ${CODE}_${OUTPUT}_local.sh  | awk '{print $2}');

--- a/NtupleProducer/python/scripts/respCorrSimple.py
+++ b/NtupleProducer/python/scripts/respCorrSimple.py
@@ -29,7 +29,14 @@ from FastPUPPI.NtupleProducer.scripts.respPlots import doRespPt
 #        python scripts/respCorrSimple.py respTupleNew_HadronGun_PU0.root plots/corr/resol -p pizero -w L1Ecal_pt02 -e L1Ecal_pt02  -r --ptmin 5 --ptmax 50
 #    Hadrons, track
 #        python scripts/respCorrSimple.py respTupleNew_HadronGun_PU0.root plots/corr/resol -p pion -w L1TK_pthighest -e L1TK_pthighest   -r --ptmin 5 --ptmax 50
-
+#
+# ================================
+#  FOR HGCal 3D-cluster based PF with a single collection of clusters, there is one single run of calibration (still based on EMF)
+#
+#  1) python scripts/respCorrSimple.py respTupleNew_HadronGun_PU0.root  plots/corr -p pimix -w L1RawHGCal_pt02 -e L1RawHGCal_pt02 --fitrange 15 50 --root hadcorr_HGCal3D.root --emf-slices L1RawHGCalEM_pt02/L1RawHGCal_pt02 0.125,0.250,0.50,0.875,1.125  --ptmax 50 --hgcal-eta
+#
+#  2) resolutions can then extracted as before but with pimix
+#     python scripts/respCorrSimple.py respTupleNew_HadronGun_PU0..root  plots/resol -p pimix -w L1HGCal_pt02 -e L1Calo_pt02  -r --ptmin 5 --ptmax 50 --hgcal-eta
 
 if __name__ == "__main__":
     from optparse import OptionParser
@@ -43,6 +50,7 @@ if __name__ == "__main__":
     parser.add_option("--xpt", "--xpt", dest="xpt",  default=("mc_pt","p_{T}^{gen}"), nargs=2)
     parser.add_option("--coarse-eta", dest="coarseEta", default=False, action="store_true")
     parser.add_option("--semicoarse-eta", dest="semiCoarseEta", default=False, action="store_true")
+    parser.add_option("--hgcal-eta", dest="hgcalEta", default=False, action="store_true")
     parser.add_option("--root", dest="rootfile", default=None)
     parser.add_option("--eta", dest="eta", nargs=2, default=None, type="float")
     parser.add_option("--ptmin", dest="ptmin", nargs=1, default=0, type="float")
@@ -89,9 +97,11 @@ if __name__ == "__main__":
             etas = [ 1.5, 3.0, 5.0 ]
             etas = [ (etas[i-1] if i else 0, etas[i]) for  i in xrange(len(etas)) if etas[i] <= options.etaMax ]
         elif options.semiCoarseEta:
-            #etas = [ 1.5, 3.0, 3.5, 3.8, 4.2, 4.4, 4.7, 5.0 ]
 	    etas = [1.5, 3.0, 3.2, 3.5, 4.0, 4.5, 5.0]
             etas = [ (etas[i-1] if i else 0, etas[i]) for  i in xrange(len(etas)) if etas[i] <= options.etaMax ]
+        elif options.hgcalEta:
+	    etas = [ 1.9, 2.2, 2.5, 2.8, 3.0 ]
+            etas = [ (etas[i-1] if i else 1.6, etas[i]) for  i in xrange(len(etas)) if etas[i] <= options.etaMax ]
         elif options.resolution:
             if "TK" in options.expr:
                 etas = [ 0.8, 1.2, 1.5, 2.0, 2.5 ]
@@ -264,7 +274,7 @@ if __name__ == "__main__":
                     frame.GetYaxis().SetTitle("p_{T}^{corr} (GeV)")
                     frame.GetYaxis().SetRangeUser(0.0, 150.0)
                     frame.Draw() 
-                    line.DrawLine(0.0,1,frame.GetXaxis().GetXmax(),150.0)
+                    line.DrawLine(0.0,0,frame.GetXaxis().GetXmax(),frame.GetXaxis().GetXmax())
                     pextra = ROOT.TGraph(199)
                     for i in xrange(200):
                         pextra.SetPoint(i, 0.5*(i+1), pclone.Eval(0.5*(i+1)))

--- a/NtupleProducer/python/scripts/respPlots.py
+++ b/NtupleProducer/python/scripts/respPlots.py
@@ -144,7 +144,7 @@ def doRespPt(oname, tree, name, expr, cut, mcpt="mc_pt", xpt="mc_pt", relative=F
             invret.Sort()
             ret.inv = invret
         ycs = [[] for ipt in ptbins]
-        iprint = 3
+        #iprint = 3
         for i in xrange(graph.GetN()):
             if yi[i] == 0: continue
             if respCorr == "gen":
@@ -274,26 +274,46 @@ whats = [
         ("Tight TK #Deltaz", "L1TightTKV$", ROOT.kViolet+2, 21, 1.2),
         ]),
     ('pfdebug',[
-        ("Gen #times Acc", "GenAcc$",           ROOT.kAzure+1,  20, 1.2),
-        ("CH #times Acc",  "ChGenAcc$",         ROOT.kAzure+2,  20, 1.2),
-        ("NE #times Acc",  "GenAcc$-ChGenAcc$", ROOT.kAzure+3,  20, 1.2),
-        ("Calo",       "L1Calo$",               ROOT.kViolet+1, 34, 1.5),
-        ("TK",         "L1TK$",                 ROOT.kRed+1,    20, 1.2),
-        ("rawTK",      "RawTK$",                ROOT.kRed+3,    20, 1.2),
-        ("PF",         "L1PF$",                 ROOT.kOrange+7, 34, 1.2),
-        ("PFCh",       "L1PFCharged$",          ROOT.kGreen+1,  34, 1.2),
-        ("PFNh",       "L1PF$-L1PFCharged$",    ROOT.kGreen+3,  34, 1.2),
+        ("Gen #times Acc", "GenAcc$",           ROOT.kGray+1,  21, 1.2),
+        ("PF",         "L1PF$",                 ROOT.kBlack,    20, 1.0),
+        ("Gen_Charged",  "ChGenAcc$",         ROOT.kAzure+10,  21, 1.5),
+        ("PF_Charged",       "L1PFCharged$",          ROOT.kBlue+2,   20, 1.3),
+        ("Gen_Neutral",  "GenAcc$-ChGenAcc$", ROOT.kGreen+0,  21, 1.2),
+        ("PF_Neutral",       "L1PF$-L1PFCharged$",    ROOT.kGreen+2,  20, 1.0),
+        ("RawTK",      "RawTK$",                ROOT.kRed+2,    34, 1.0),
+        ("TK",         "L1TK$",                 ROOT.kRed+0,    34, 1.0),
+        ("Calo",       "L1Calo$",               ROOT.kViolet+1, 34, 1.0),
     ]),
-    ('pfdebug2',[
-        ("Gen #times Acc", "GenAcc$",           ROOT.kAzure+1,  20, 1.2),
-        ("PH #times Acc",  "PhGenAcc$",         ROOT.kAzure+2,  20, 1.2),
-        ("NE #times Acc",  "GenAcc$-ChGenAcc$-PhGenAcc$", ROOT.kRed+1,  20, 1.2),
-        ("Calo",       "L1Calo$",               ROOT.kViolet+1, 34, 1.5),
-        ("PF",         "L1PF$",                 ROOT.kOrange+7, 34, 1.2),
-        ("PFPh",       "L1PFPhoton$",           ROOT.kGreen+2,  34, 1.2),
-        ("PFNh",       "L1PF$-L1PFCharged$-L1PFPhoton$",    ROOT.kRed+1,  34, 1.2),
+     ('pfdebug2',[
+        ("Gen #times Acc", "GenAcc$",           ROOT.kGray+1,  21, 1.2),
+        ("PF",         "L1PF$",                 ROOT.kBlack,    20, 1.0),
+        ("Gen_Photon",  "PhGenAcc$",         ROOT.kGreen+0,  21, 1.2),
+        ("PF_Photon",       "L1PFPhoton$",           ROOT.kGreen+2,  20, 1.0),
+        ("Gen_NeutralHad",  "GenAcc$-ChGenAcc$-PhGenAcc$", ROOT.kRed-4,  21, 1.2),
+        ("PF_NeutralHad",   "L1PF$-L1PFCharged$-L1PFPhoton$",  ROOT.kRed+2,  20, 1.0),
     ]),
+    ('puppidebug',[
+        ("Gen #times Acc", "GenAcc$",         ROOT.kGray+1,  21, 1.2),
+        ("PF",             "L1PF$",           ROOT.kGray+2,   24, 1.0),
+        ("Puppi",          "L1Puppi$",        ROOT.kBlack,    20, 1.0),
+        ("Gen_Charged",  "ChGenAcc$",         ROOT.kAzure+10,  21, 1.5),
+        ("PF_Charged",       "L1PFCharged$",          ROOT.kBlue+2,   24, 1.3),
+        ("Puppi_Charged",       "L1PuppiCharged$",    ROOT.kBlue+2,   20, 1.3),
+        ("Gen_Neutral",    "GenAcc$-ChGenAcc$", ROOT.kGreen+0,  21, 1.2),
+        ("PF_Neutral",     "L1PF$-L1PFCharged$",        ROOT.kGreen+2,  24, 1.0),
+        ("Puppi_Neutral",  "L1Puppi$-L1PuppiCharged$",  ROOT.kGreen+2,  20, 1.0),
+        ("TK",         "L1TK$",                 ROOT.kRed+0,    34, 1.0),
+        ("TKV",        "L1TKV$",                ROOT.kRed+2,    34, 1.0),
     ]),
+     ('puppidebug2',[
+        ("Gen #times Acc", "GenAcc$",           ROOT.kGray+1,  21, 1.2),
+        ("PF",         "L1PF$",                 ROOT.kBlack,    20, 1.0),
+        ("Gen_Photon",  "PhGenAcc$",         ROOT.kGreen+0,  21, 1.2),
+        ("PF_Photon",       "L1PFPhoton$",           ROOT.kGreen+2,  20, 1.0),
+        ("Gen_NeutralHad",  "GenAcc$-ChGenAcc$-PhGenAcc$", ROOT.kRed-4,  21, 1.2),
+        ("PF_NeutralHad",   "L1PF$-L1PFCharged$-L1PFPhoton$",  ROOT.kRed+2,  20, 1.0),
+    ]),
+
     ('pfcomp4',[
         ("Global",    "L1PFGlobal$",   ROOT.kGreen+1,  20, 1.2),
         ("Regional",  "L1PFRegional$", ROOT.kAzure+1,  24, 1.2),
@@ -498,7 +518,7 @@ if __name__ == "__main__":
                         p.Draw("P SAME" if "TGraph" in p.ClassName() else "SAME")
                         if hasattr(p,'fit') and not options.noFit: p.fit.Draw("SAME")
                     for n,p in plots: 
-                        leg.AddEntry(p, n, "LP")
+                        leg.AddEntry(p, n.replace("_"," "), "LP")
                         if hasattr(p,'fit') and not options.noFit: 
                             if "resolution" in ptype:
                                 if ("Trk" in n or "TK" in n) and ("jet" not in oname) and ("ele" not in oname):


### PR DESCRIPTION
Goes together with https://github.com/p2l1pfp/cmssw/pull/7

* runNewInputs.py is modified to include the new 3D cluster collections (old collections are also kept)
* runRespNTuplerNew.py still runs the old PF (based on HGC towers)
* runRespNTuplerNew3D.py runs the new PF (based on HGC 3D clusters)
* runIDNTuplerHGCTune.py is a new ntuplizer for 3D cluster properties

Inputs containing the old clusters for runRespNTuplerNew.py (produced with HGCal v3)  are in 
`/eos/cms/store/cmst3/group/l1tr/gpetrucc/101X/NewInputs/231018` (this is the default in prun.sh). This set of inputs also contains the HGC VFE information necessary to re-run any HGCal  concentrator and clustering configuration.

Inputs containing the new 3D clusters for runRespNTuplerNew3D.py are in `/eos/cms/store/cmst3/group/l1tr/gpetrucc/101X/NewInputs/011118` (can be selected in prun.sh with the option `--3D`). These contain only the superTCs, so while it's possible to re-run a modified 3D clustering it's not possible to re-run a modified concentrator emulation