### PR TITLE
Update to latest L1PF_10_6_1p2_X 

### DIFF
--- a/NtupleProducer/BuildFile.xml
+++ b/NtupleProducer/BuildFile.xml
@@ -4,7 +4,7 @@
 <use name="DataFormats/JetReco"/>
 <use name="DataFormats/METReco"/>
 <use name="RecoMET/METAlgorithms"/>
-<use name="FastSimulation/BaseParticlePropagator"/>
+<use name="CommonTools/BaseParticlePropagator"/>
 <use name="DataFormats/ParticleFlowReco"/>
 <use name="SimDataFormats/CaloAnalysis"/>
 <use name="DataFormats/L1THGCal"/>

--- a/NtupleProducer/README.md
+++ b/NtupleProducer/README.md
@@ -1,11 +1,11 @@
 Basic Instructions
 
 ```
-cmsrel CMSSW_10_6_0_prer4
-cd CMSSW_10_6_pre4/src
+cmsrel CMSSW_10_6_1_patch2
+cd CMSSW_10_6_1_patch2/src
 cmsenv
 git cms-init
-git cms-checkout-topic -u p2l1pfp:L1PF_10_6_X
+git cms-checkout-topic -u p2l1pfp:L1PF_10_6_1p2_X
 
 # scripts
 git clone git@github.com:p2l1pfp/FastPUPPI.git -b 106X
@@ -34,12 +34,11 @@ cmsRun runRespNTupler.py
 
 NB: 
    * For single particle add `goGun()` at the end of the script, remove it for jets.
-   * For 93X samples, add a `goOld()` at the end of the script to select 93X calibrations (note that these are not updated at the moment)
 
 To run the ntuplizer over many files, from within `NtupleProducer/python` do for instance:
 ```
-./scripts/prun.sh runRespNTupler.py --v3 TTbar_PU0 TTbar_PU0
-./scripts/prun.sh runRespNTupler.py --v3 SinglePion_PU0 SinglePion_PU0  --inline-customize 'goGun()'
+./scripts/prun.sh runRespNTupler.py --v0 TTbar_PU0 TTbar_PU0.v0
+./scripts/prun.sh runRespNTupler.py --v0 ParticleGun_PU0 ParticleGun_PU0.v0  --inline-customize 'goGun()'
 ```
 Look into the prun.sh script to check the paths to the input files and the corresponding options.
 
@@ -53,7 +52,7 @@ This produces both a response ntuple like the one for the runRespNTupler.py, but
 To run the ntuplizer over many files do for instance:
 
 ```
-./scripts/prun.sh runPerformanceNTuple.py TTbar_PU200 TTbar_PU200
+./scripts/prun.sh runPerformanceNTuple.py --v0  TTbar_PU200 TTbar_PU200.v0
 ```
 
 The third step is to produce the plots from the ntuple. The plotting scripts are in:
@@ -62,18 +61,18 @@ The third step is to produce the plots from the ntuple. The plotting scripts are
 1) For single particle or jet response:
 
 ```
-python scripts/respPlots.py respTupleNew_SinglePion_PU0.root plots_dir -w l1pfnew -p pion
-python scripts/respPlots.py respTupleNew_TTbar_PU200.root plots_dir -w l1pfnew -p jet
+python scripts/respPlots.py respTupleNew_SinglePion_PU0.v0.root plots_dir -w l1pfw -p pion
+python scripts/respPlots.py respTupleNew_TTbar_PU200.v0.root plots_dir -w l1pf -p jet
 ```
 
 2) For jet, MET and HT plots, the first step is to produce JECs
 ```
-python scripts/makeJecs.py perfNano_TTbar_PU200.root -A -o jecs.root
+python scripts/makeJecs.py perfNano_TTbar_PU200.v0.root -A -o jecs.root
 ```
 then you can use `jetHtSuite.py` to make the plots
 
 ```
-python scripts/jetHtSuite.py perfNano_TTbar_PU200.root perfNano_SingleNeutrino_PU200.root plots_dir -w oldcomp,newcomp -v ht
-python scripts/jetHtSuite.py perfNano_TTbar_PU200.root perfNano_SingleNeutrino_PU200.root plots_dir -w oldcomp,newcomp -v met
-python scripts/jetHtSuite.py perfNano_TTbar_PU200.root perfNano_SingleNeutrino_PU200.root plots_dir -w oldcomp,newcomp -v jet4
+python scripts/jetHtSuite.py perfNano_TTbar_PU200.root perfNano_SingleNeutrino_PU200.root plots_dir -w l1pfpu -v ht
+python scripts/jetHtSuite.py perfNano_TTbar_PU200.root perfNano_SingleNeutrino_PU200.root plots_dir -w l1pfpu -v met
+python scripts/jetHtSuite.py perfNano_TTbar_PU200.root perfNano_SingleNeutrino_PU200.root plots_dir -w l1pfpu -v jet4
 ```

--- a/NtupleProducer/README.md
+++ b/NtupleProducer/README.md
@@ -52,7 +52,7 @@ This produces both a response ntuple like the one for the runRespNTupler.py, but
 To run the ntuplizer over many files do for instance:
 
 ```
-./scripts/prun.sh runPerformanceNTuple.py --v0  TTbar_PU200 TTbar_PU200.v0
+./scripts/prun.sh runPerformanceNTuple.py --v0  TTbar_PU200 TTbar_PU200.v0 --inline-customize 'addCHS();addTKs()';
 ```
 
 The third step is to produce the plots from the ntuple. The plotting scripts are in:
@@ -78,8 +78,15 @@ python scripts/jetHtSuite.py perfNano_TTbar_PU200.root perfNano_SingleNeutrino_P
 ```
 
 3) For object multiplicitly studies:
+
+Plot the number of elements in a given detector (`Barrel`, `HGCal`, `HGCalNoTK`, `HF`): 
 ```
-python objMultiplicityPlot.py ../perfTuple.root objplots -d l1pfProducerBarrel --cl 0.95
-python objMultiplicityPlot.py ../perfTuple.root objplots -d l1pfProducerHF --cl 0.95
-python objMultiplicityPlot.py ../perfTuple.root objplots -d l1pfProducerHGCal --cl 0.95
+python scripts/objMultiplicityPlot.py perfTuple_TTbar_PU200.root -d Barrel plotdir 
+```
+ * note: you should add `goRegional()` to the options in `runPerformanceNTuple.py` if you want to get meaningful numbers per region and not just overall
+
+
+Print out the multiplicities needed to avoid truncation at a given confidence level
+```
+python scripts/objMultiplicityPlot.py perfTuple_TTbar_PU200.root -d HF --cl 0.95
 ```

--- a/NtupleProducer/README.md
+++ b/NtupleProducer/README.md
@@ -77,3 +77,10 @@ python scripts/jetHtSuite.py perfNano_TTbar_PU200.root perfNano_SingleNeutrino_P
 python scripts/jetHtSuite.py perfNano_TTbar_PU200.root perfNano_SingleNeutrino_PU200.root plots_dir -w oldcomp,newcomp -v met
 python scripts/jetHtSuite.py perfNano_TTbar_PU200.root perfNano_SingleNeutrino_PU200.root plots_dir -w oldcomp,newcomp -v jet4
 ```
+
+3) For object multiplicitly studies:
+```
+python objMultiplicityPlot.py ../perfTuple.root objplots -d l1pfProducerBarrel --cl 0.95
+python objMultiplicityPlot.py ../perfTuple.root objplots -d l1pfProducerHF --cl 0.95
+python objMultiplicityPlot.py ../perfTuple.root objplots -d l1pfProducerHGCal --cl 0.95
+```

--- a/NtupleProducer/python/runInputs104X.py
+++ b/NtupleProducer/python/runInputs104X.py
@@ -56,7 +56,7 @@ process.out = cms.OutputModule("PoolOutputModule",
             "keep *_hgcalConcentratorProducer*_*_IN",
             #"keep *_hgcalBackEndLayer1Producer*_*_IN",
             "keep *_hgcalBackEndLayer2Producer*_*_IN",
-            "keep *_hgcalTowerMapProducer_*_IN",
+            #"keep *_hgcalTowerMapProducer_*_IN",
             "keep *_hgcalTowerProducer_*_IN",
             # muons
             "keep *_simGmtStage2Digis__*",

--- a/NtupleProducer/python/runPerformanceNTuple.py
+++ b/NtupleProducer/python/runPerformanceNTuple.py
@@ -12,7 +12,9 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1))
 process.MessageLogger.cerr.FwkReport.reportEvery = 1
 
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('file:/eos/cms/store/cmst3/user/gpetrucc/l1tr/105X/NewInputs104X/010319/TTbar_PU200/inputs104X_TTbar_PU200_job1.root'),
+                            fileNames = cms.untracked.vstring(
+                                'file:/eos/cms/store/cmst3/user/gpetrucc/l1tr/105X/NewInputs104X/010319/TTbar_PU200/inputs104X_TTbar_PU200_job1.root',
+                            ),
     duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
     skipBadFiles = cms.untracked.bool(True),
     inputCommands = cms.untracked.vstring("keep *", 
@@ -56,7 +58,8 @@ process.extraPFStuff.add(
     process.genMetBarrelTrue
 )
 
-def monitorPerf(label, tag, makeResp=True, makeRespSplit=True, makeJets=True, makeMET=True, makeCentralMET=True, makeBarrelMET=True):
+def monitorPerf(label, tag, makeResp=True, makeRespSplit=True, makeJets=True, makeMET=True, makeCentralMET=True, makeBarrelMET=True,
+                makeInputMultiplicities=False, makeOutputMultiplicities=False):
     def _add(name, what):
         setattr(process, name, what)
         process.extraPFStuff.add(what)
@@ -88,6 +91,19 @@ def monitorPerf(label, tag, makeResp=True, makeRespSplit=True, makeJets=True, ma
             _add('barrel'+label, cms.EDFilter("CandPtrSelector", src = cms.InputTag(tag), cut = cms.string("abs(eta) < 1.5")))
             _add('met'+label+'Barrel', pfMet.clone(src = 'barrel'+label, calculateSignificance = False))
             setattr(process.l1pfmetBarrelTable.mets, label, cms.InputTag('met'+label+'Barrel'))
+    if makeInputMultiplicities:
+        D = tag.split(":")[0] # l1pfProducer[Barrel,HGCal,HF] usually
+        I = tag.split(":")[1] # Calo, EmCalo, TK, or Mu, usually
+        for X in ["tot","max"]:
+            process.ntuple.copyUInts.append( "%s:%sNL1%s" % (D,X,I))
+        process.ntuple.copyVecUInts.append( "%s:vecNL1%s" % (D,I))
+    if makeOutputMultiplicities:
+        D = tag.split(":")[0] # l1pfProducer[Barrel,HGCal,HF] usually
+        P = tag.split(":")[1] # PF or Puppi, usually
+        for O in [""] + "Charged Neutral ChargedHadron NeutralHadron Photon Electron Muon".split():
+            for X in ["tot","max"]:
+                process.ntuple.copyUInts.append( "%s:%sNL1%s%s" % (D,X,P,O))
+            process.ntuple.copyVecUInts.append( "%s:vecNL1%s%s" % (D,P,O))
 
 process.ntuple = cms.EDAnalyzer("ResponseNTuplizer",
     genJets = cms.InputTag("ak4GenJetsNoNu"),
@@ -103,21 +119,6 @@ process.ntuple = cms.EDAnalyzer("ResponseNTuplizer",
     copyFloats = cms.VInputTag(),
     copyVecUInts = cms.VInputTag(),
 )
-
-for X in ["tot","max"]:
-    for D in ['l1pfProducerBarrel', 'l1pfProducerHF', 'l1pfProducerHGCal', 'l1pfProducerHGCalNoTK']:
-        for I in "Calo EmCalo TK Mu".split(): 
-            process.ntuple.copyUInts.append( "%s:%sNL1%s" % (D,X,I))
-        for O in [""] + "Charged Neutral ChargedHadron NeutralHadron Photon Electron Muon".split():
-            process.ntuple.copyUInts.append( "%s:%sNL1PF%s" % (D,X,O))
-            process.ntuple.copyUInts.append( "%s:%sNL1Puppi%s" % (D,X,O))
-
-for D in ['l1pfProducerBarrel', 'l1pfProducerHF', 'l1pfProducerHGCal', 'l1pfProducerHGCalNoTK']:
-    for I in "Calo EmCalo TK Mu".split(): 
-        process.ntuple.copyVecUInts.append( "%s:vecNL1%s" % (D,I))
-    for O in [""] + "Charged Neutral ChargedHadron NeutralHadron Photon Electron Muon".split():
-        process.ntuple.copyVecUInts.append( "%s:vecNL1PF%s" % (D,O))
-        process.ntuple.copyVecUInts.append( "%s:vecNL1Puppi%s" % (D,O))
 
 process.extraPFStuff.add(process.pfTracksFromL1Tracks)
 
@@ -150,62 +151,78 @@ monitorPerf("L1TKV", "l1pfCandidates:TKVtx", makeRespSplit = False, makeJets=Fal
 monitorPerf("L1PF", "l1pfCandidates:PF")
 monitorPerf("L1Puppi", "l1pfCandidates:Puppi")
 
+for D in ['Barrel','HF','HGCal','HGCalNoTK']:
+    monitorPerf("L1%sCalo"%D,"l1pfProducer%s:Calo"%D, makeResp=False, makeRespSplit=False, makeJets=False, makeMET=False, 
+               makeCentralMET=False, makeBarrelMET=False, makeInputMultiplicities=True)
+    monitorPerf("L1%sEmCalo"%D,"l1pfProducer%s:EmCalo"%D, makeResp=False, makeRespSplit=False, makeJets=False, makeMET=False, 
+               makeCentralMET=False, makeBarrelMET=False, makeInputMultiplicities=True)
+    monitorPerf("L1%sTK"%D,"l1pfProducer%s:TK"%D, makeResp=False, makeRespSplit=False, makeJets=False, makeMET=False, 
+               makeCentralMET=False, makeBarrelMET=False, makeInputMultiplicities=True)
+    monitorPerf("L1%sMu"%D,"l1pfProducer%s:Mu"%D, makeResp=False, makeRespSplit=False, makeJets=False, makeMET=False, 
+               makeCentralMET=False, makeBarrelMET=False, makeInputMultiplicities=True)
+
+    monitorPerf("L1%sPF"%D,"l1pfProducer%s:PF"%D, makeResp=False, makeRespSplit=False, makeJets=False, makeMET=False, 
+               makeCentralMET=False, makeBarrelMET=False, makeOutputMultiplicities=True)
+    monitorPerf("L1%sPuppi"%D,"l1pfProducer%s:Puppi"%D, makeResp=False, makeRespSplit=False, makeJets=False, makeMET=False, 
+               makeCentralMET=False, makeBarrelMET=False, makeOutputMultiplicities=True)
+
 # define regions
 def goRegional():
     process.l1pfProducerBarrel.regions = cms.VPSet(
         cms.PSet(
-            etaBoundaries = cms.vdouble(-1.5, -1, -0.5, 0, 0.5, 1, 1.5),
-            etaExtra = cms.double(0.3),
-            phiExtra = cms.double(0.3),
-            phiSlices = cms.uint32(10)
+            etaBoundaries = cms.vdouble(-1.5, -0.75, 0, 0.75, 1.5),
+            etaExtra = cms.double(0.0),
+            phiExtra = cms.double(0.0),
+            phiSlices = cms.uint32(9)
         )
     )
     process.l1pfProducerHGCalNoTK.regions = cms.VPSet(
         cms.PSet(
             etaBoundaries = cms.vdouble(-3, -2.5),
-            etaExtra = cms.double(0.3),
-            phiExtra = cms.double(0.3),
-            phiSlices = cms.uint32(10)
+            etaExtra = cms.double(0.0),
+            phiExtra = cms.double(0.0),
+            phiSlices = cms.uint32(9)
         ),
         cms.PSet(
             etaBoundaries = cms.vdouble(2.5, 3),
-            etaExtra = cms.double(0.3),
-            phiExtra = cms.double(0.3),
-            phiSlices = cms.uint32(10)
+            etaExtra = cms.double(0.0),
+            phiExtra = cms.double(0.0),
+            phiSlices = cms.uint32(9)
         )
     )
     process.l1pfProducerHGCal.regions = cms.VPSet(
         cms.PSet(
-            etaBoundaries = cms.vdouble(-2.5, -2, -1.5),
-            etaExtra = cms.double(0.3),
-            phiExtra = cms.double(0.3),
-            phiSlices = cms.uint32(10)
+            etaBoundaries = cms.vdouble(-2.5, -1.5),
+            etaExtra = cms.double(0.0),
+            phiExtra = cms.double(0.0),
+            phiSlices = cms.uint32(9)
         ),
         cms.PSet(
-            etaBoundaries = cms.vdouble(1.5, 2, 2.5),
-            etaExtra = cms.double(0.3),
-            phiExtra = cms.double(0.3),
-            phiSlices = cms.uint32(10)
+            etaBoundaries = cms.vdouble(1.5, 2.5),
+            etaExtra = cms.double(0.0),
+            phiExtra = cms.double(0.0),
+            phiSlices = cms.uint32(9)
         )
     )
     process.l1pfProducerHF.regions = cms.VPSet(
         cms.PSet(
             etaBoundaries = cms.vdouble(-5, -4.5, -4, -3.5, -3),
-            etaExtra = cms.double(0.3),
-            phiExtra = cms.double(0.3),
-            phiSlices = cms.uint32(10)
+            etaExtra = cms.double(0.0),
+            phiExtra = cms.double(0.0),
+            phiSlices = cms.uint32(9)
         ),
         cms.PSet(
             etaBoundaries = cms.vdouble(3, 3.5, 4, 4.5, 5),
-            etaExtra = cms.double(0.3),
-            phiExtra = cms.double(0.3),
-            phiSlices = cms.uint32(10)
+            etaExtra = cms.double(0.0),
+            phiExtra = cms.double(0.0),
+            phiSlices = cms.uint32(9)
         )
     )
 
 goRegional()
 
 process.runPF.associate(process.extraPFStuff)
+# to check available tags:
 #process.content = cms.EDAnalyzer("EventContentAnalyzer")
 process.p = cms.Path(
         process.runPF + 
@@ -214,6 +231,13 @@ process.p = cms.Path(
         process.l1pfmetTable + process.l1pfmetCentralTable + process.l1pfmetBarrelTable
         )
 process.TFileService = cms.Service("TFileService", fileName = cms.string("perfTuple.root"))
+
+# for full debug:
+#process.out = cms.OutputModule("PoolOutputModule",
+#                               fileName = cms.untracked.string("debugPF.root"),
+#                               SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("p"))
+#                           )
+#process.end = cms.EndPath(process.out)
 
 process.outnano = cms.OutputModule("NanoAODOutputModule",
     fileName = cms.untracked.string("perfNano.root"),

--- a/NtupleProducer/python/runPerformanceNTuple.py
+++ b/NtupleProducer/python/runPerformanceNTuple.py
@@ -219,8 +219,6 @@ def goRegional():
         )
     )
 
-goRegional()
-
 process.runPF.associate(process.extraPFStuff)
 # to check available tags:
 #process.content = cms.EDAnalyzer("EventContentAnalyzer")
@@ -397,12 +395,3 @@ def goGun(calib=1):
 def goMT(nthreads=2):
     process.options.numberOfThreads = cms.untracked.uint32(nthreads)
     process.options.numberOfStreams = cms.untracked.uint32(0)
-def goOld():
-    process.pfClustersFromL1EGClusters.corrector  = "L1Trigger/Phase2L1ParticleFlow/data/emcorr_barrel_93X.root"
-    process.pfClustersFromHGC3DClustersEM.corrector =  "L1Trigger/Phase2L1ParticleFlow/data/emcorr_hgc_old3d_93X.root"
-    process.pfClustersFromCombinedCalo.hadCorrector =  "L1Trigger/Phase2L1ParticleFlow/data/hadcorr_93X.root"
-    process.pfClustersFromHGC3DClusters.corrector =  "L1Trigger/Phase2L1ParticleFlow/data/hadcorr_HGCal3D_STC_93X.root"
-    process.pfClustersFromCombinedCaloHCal.hadCorrector =  "L1Trigger/Phase2L1ParticleFlow/data/hadcorr_barrel_93X.root"
-    process.pfClustersFromCombinedCaloHF.hadCorrector =  "L1Trigger/Phase2L1ParticleFlow/data/hfcorr_93X.root"
-
-

--- a/NtupleProducer/python/runPerformanceNTuple.py
+++ b/NtupleProducer/python/runPerformanceNTuple.py
@@ -171,50 +171,50 @@ def goRegional():
     process.l1pfProducerBarrel.regions = cms.VPSet(
         cms.PSet(
             etaBoundaries = cms.vdouble(-1.5, -0.75, 0, 0.75, 1.5),
-            etaExtra = cms.double(0.0),
-            phiExtra = cms.double(0.0),
+            etaExtra = cms.double(0.25),
+            phiExtra = cms.double(0.25),
             phiSlices = cms.uint32(9)
         )
     )
     process.l1pfProducerHGCalNoTK.regions = cms.VPSet(
         cms.PSet(
             etaBoundaries = cms.vdouble(-3, -2.5),
-            etaExtra = cms.double(0.0),
-            phiExtra = cms.double(0.0),
+            etaExtra = cms.double(0.25),
+            phiExtra = cms.double(0.25),
             phiSlices = cms.uint32(9)
         ),
         cms.PSet(
             etaBoundaries = cms.vdouble(2.5, 3),
-            etaExtra = cms.double(0.0),
-            phiExtra = cms.double(0.0),
+            etaExtra = cms.double(0.25),
+            phiExtra = cms.double(0.25),
             phiSlices = cms.uint32(9)
         )
     )
     process.l1pfProducerHGCal.regions = cms.VPSet(
         cms.PSet(
             etaBoundaries = cms.vdouble(-2.5, -1.5),
-            etaExtra = cms.double(0.0),
-            phiExtra = cms.double(0.0),
+            etaExtra = cms.double(0.25),
+            phiExtra = cms.double(0.25),
             phiSlices = cms.uint32(9)
         ),
         cms.PSet(
             etaBoundaries = cms.vdouble(1.5, 2.5),
-            etaExtra = cms.double(0.0),
-            phiExtra = cms.double(0.0),
+            etaExtra = cms.double(0.25),
+            phiExtra = cms.double(0.25),
             phiSlices = cms.uint32(9)
         )
     )
     process.l1pfProducerHF.regions = cms.VPSet(
         cms.PSet(
             etaBoundaries = cms.vdouble(-5, -4.5, -4, -3.5, -3),
-            etaExtra = cms.double(0.0),
-            phiExtra = cms.double(0.0),
+            etaExtra = cms.double(0.25),
+            phiExtra = cms.double(0.25),
             phiSlices = cms.uint32(9)
         ),
         cms.PSet(
             etaBoundaries = cms.vdouble(3, 3.5, 4, 4.5, 5),
-            etaExtra = cms.double(0.0),
-            phiExtra = cms.double(0.0),
+            etaExtra = cms.double(0.25),
+            phiExtra = cms.double(0.25),
             phiSlices = cms.uint32(9)
         )
     )

--- a/NtupleProducer/python/runPerformanceNTuple.py
+++ b/NtupleProducer/python/runPerformanceNTuple.py
@@ -102,6 +102,15 @@ process.ntuple = cms.EDAnalyzer("ResponseNTuplizer",
     copyUInts = cms.VInputTag(),
     copyFloats = cms.VInputTag(),
 )
+
+for X in ["tot","max"]:
+    for D in ['l1pfProducerBarrel', 'l1pfProducerHF', 'l1pfProducerHGCal']:
+        for I in "Calo EmCalo TK Mu".split(): 
+            process.ntuple.copyUInts.append( "%s:%sNL1%s" % (D,X,I))
+        for O in [""] + "Charged Neutral ChargedHadron NeutralHadron Photon Electron Muon".split():
+            process.ntuple.copyUInts.append( "%s:%sNL1PF%s" % (D,X,O))
+            process.ntuple.copyUInts.append( "%s:%sNL1Puppi%s" % (D,X,O))
+
 process.extraPFStuff.add(process.pfTracksFromL1Tracks)
 
 
@@ -134,9 +143,10 @@ monitorPerf("L1PF", "l1pfCandidates:PF")
 monitorPerf("L1Puppi", "l1pfCandidates:Puppi")
 
 process.runPF.associate(process.extraPFStuff)
+#process.content = cms.EDAnalyzer("EventContentAnalyzer")
 process.p = cms.Path(
         process.runPF + 
-        process.ntuple + 
+        process.ntuple + #process.content +
         process.l1pfjetTable + 
         process.l1pfmetTable + process.l1pfmetCentralTable + process.l1pfmetBarrelTable
         )

--- a/NtupleProducer/python/scripts/correlateRespTuple.py
+++ b/NtupleProducer/python/scripts/correlateRespTuple.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+import ROOT
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+ROOT.gROOT.SetBatch(True)
+
+import os
+from sys import argv
+
+from collections import defaultdict
+
+from PhysicsTools.HeppyCore.utils.deltar import *
+from PhysicsTools.HeppyCore.statistics.tree import *
+
+
+from optparse import OptionParser
+parser = OptionParser("%(prog) -w what infile1 infile2 ")
+parser.add_option("--id", "--mc_id", dest="mc_id", type=int, nargs=1, default=0, help="MC ")
+parser.add_option("-w", "--what", dest="what", action="append", default=[])
+parser.add_option("-o", "--out", dest="out", default="correlatedRespTuple.root")
+options, args = parser.parse_args()
+nfiles = len(args)
+
+fout = ROOT.TFile(options.out, "RECREATE")
+otree = Tree("t","t","F")
+for x in "run","lumi","event","mc_id": otree.var(x,int);
+for x in "pt","eta","phi": otree.var("mc_"+x);
+for j in range(nfiles):
+    for x in options.what:  otree.var("%s_%d" % (x,j))
+
+events = {}
+
+for ia, arg in enumerate(args):
+    tfile = ROOT.TFile(arg)
+    tree = tfile.Get("ntuple/tree")
+    for e in tree:
+        if e.mc_id != options.mc_id: continue
+        evid = e.run, e.lumi, e.event
+        if evid not in events: 
+            if ia != 0: continue
+            events[evid] = {}
+        pid = tuple(map(int, (e.mc_pt*100, e.mc_eta*100, e.mc_phi*100)))
+        if ia == 0: 
+            events[evid][pid] = [ [ getattr(e,x) for x in options.what ] ]
+        else:
+            if pid not in events[evid]: continue
+            events[evid][pid].append( [ getattr(e,x) for x in options.what ] )
+
+print "Found %d events" % len(events)
+
+otree.fill("mc_id", options.mc_id)
+for evid, pids in sorted(events.iteritems()):
+    otree.fill("run", evid[0])
+    otree.fill("lumi", evid[1])
+    otree.fill("event", evid[2])
+    for pid, data in pids.iteritems():
+        otree.fill("mc_pt", 0.01*pid[0])
+        otree.fill("mc_eta", 0.01*pid[1])
+        otree.fill("mc_phi", 0.01*pid[2])
+        for j, row in enumerate(data):
+            for (x,v) in zip(options.what,row):
+                otree.fill("%s_%d" % (x,j), v)
+        otree.tree.Fill()
+print ""
+print "Output entries: %d" % otree.tree.GetEntries()
+fout.cd()
+fout.WriteTObject(otree.tree)
+fout.Close()
+        
+
+

--- a/NtupleProducer/python/scripts/doRespCorrs.sh
+++ b/NtupleProducer/python/scripts/doRespCorrs.sh
@@ -82,7 +82,7 @@ case $W in
          for f in $NTUPLES; do test -f $f && mv -v $f ${f/$V/$V.0}; done
          for X in Particle{Gun,GunPt0p5To5,GunPt80To300}_${PU}; do 
              ./scripts/prun.sh runRespNTupler.py $SAMPLES $X ${X}.${V}  --inline-customize 'goGun()'; 
-             grep -q '^JOBS:.*, 0 passed' respTupleNew_${X}.${V}.report.txt && echo " === ERROR. Will stop here === " && break;
+             grep -q '^JOBS:.*, 0 passed' respTupleNew_${X}.${V}.report.txt && echo " === ERROR. Will stop here === " && break || true;
          done
          ;;
     plot-ecal)

--- a/NtupleProducer/python/scripts/doRespCorrs.sh
+++ b/NtupleProducer/python/scripts/doRespCorrs.sh
@@ -1,19 +1,24 @@
 #!/bin/bash
 
-V="v3"
-PLOTDIR="plots/105X/from104X/${V}/corr"
-SAMPLES="--v3";
+V="v1"
+PLOTDIR="plots/106X/from104X/${V}/corr"
+SAMPLES="--104X";
 
 PU=PU0
 if [[ "$1" == "--pu200" ]]; then 
     PU=PU200; shift;
 fi;
 
+TUPLE="respTupleNew";
+if [[ "$1" == "--perf" ]]; then
+    TUPLE="perfTuple"; shift;
+fi
+
 if [[ "$1" == "--backup" ]]; then
-    NTUPLES=$(ls respTupleNew_Particle{Gun,GunPt0p5To5,GunPt80To300}_${PU}.${V}.0.root);
+    NTUPLES=$(ls ${TUPLE}_Particle{Gun,GunPt0p5To5,GunPt80To300}_${PU}.${V}.0.root);
     shift;
 else
-    NTUPLES=$(ls respTupleNew_Particle{Gun,GunPt0p5To5,GunPt80To300}_${PU}.${V}.root);
+    NTUPLES=$(ls ${TUPLE}_Particle{Gun,GunPt0p5To5,GunPt80To300}_${PU}.${V}.root);
 fi;
 
 W=$1; shift;
@@ -51,7 +56,7 @@ case $W in
          ;;
     res-had-barrel)
          python scripts/respCorrSimple.py $NTUPLES $PLOTDIR/$W -p pion -w L1BarrelCalo_pt -e L1BarrelCalo_pt --fitrange 15 80  --barrel-eta -r && \
-         echo "Put this into l1ParticleFlow_split_cff.py under pfClustersFromCombinedCaloHCal" 
+         echo "Put this into l1ParticleFlow_cff.py under pfClustersFromCombinedCaloHCal" 
          ;;
     res-had-oldstyle)
          python scripts/respCorrSimple.py $NTUPLES $PLOTDIR/$W -p pion -w L1OldCalo_pt -e L1OldCalo_pt --fitrange 15 80  -r && \
@@ -97,15 +102,28 @@ case $W in
     plot-hf)
          python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -p pizero,pion,pimix --gauss -w debug-hf --eta 3.0 5.0  --ymax 3 --ymaxRes 1.5 --ptmax 150 --no-fit --ptdef pt02,ptbest
          ;;
-    plots-pfnew)
+    plots-pf)
          if [[ "$PU" == "PU0" ]]; then
-             python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pfnew -p electron,photon,pizero -g  --ymaxRes 0.35 --ptmax 150 -E 3.0
-             python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pfnew -p pion,klong,pimix       -g  --ymaxRes 1.2  --ptmax 150 -E 3.0
-             python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pfnew -p pion,pizero,pimix      -g  --eta 3.0 5.0  --ymax 3 --ymaxRes 1.5 --label hf  --no-fit 
+             python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p electron,photon,pizero -g  --ymaxRes 0.35 --ptmax 150 -E 3.0
+             python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p pion,klong,pimix       -g  --ymaxRes 1.2  --ptmax 150 -E 3.0
+             python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p pion,pizero,pimix      -g  --eta 3.0 5.0  --ymax 3 --ymaxRes 1.5 --label hf  --no-fit 
          else
-             python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pfnew -p electron,photon,pizero -g  --ymax 2.5 --ymaxRes 0.6 --ptmax 80 -E 3.0
-             python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pfnew -p pion,klong,pimix       -g  --ymax 2.5 --ymaxRes 1.5 --ptmax 80 -E 3.0
-             python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pfnew -p pion,pizero,pimix      -g  --ymax 3.0 --ymaxRes 1.5 --ptmax 80 --eta 3.0 5.0 --label hf  --no-fit 
+             python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p electron,photon,pizero -g  --ymax 2.5 --ymaxRes 0.6 --ptmax 80 -E 3.0
+             python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p pion,klong,pimix       -g  --ymax 2.5 --ymaxRes 1.5 --ptmax 80 -E 3.0
+             python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p pion,pizero,pimix      -g  --ymax 3.0 --ymaxRes 1.5 --ptmax 80 --eta 3.0 5.0 --label hf  --no-fit 
+         fi;
+         ;;
+    plots-pfcomp)
+         if [[ "$PU" == "PU0" ]]; then
+             python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pfcomp -p electron,photon,pizero -g  --ymaxRes 0.35 --ptmax 150 -E 3.0
+             python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pfcomp -p pion,klong,pimix       -g  --ymaxRes 1.2  --ptmax 150 -E 3.0
+             python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pfcomp -p electron,photon,pizero -g  --ymaxRes 0.35 --ptmax 50 -E 3.0 --label lowpt
+             python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pfcomp -p pion,klong,pimix       -g  --ymaxRes 1.2  --ptmax 50 -E 3.0 --label lowpt
+             python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pfcomp -p pion,pizero,pimix      -g  --eta 3.0 5.0  --ymax 3 --ymaxRes 1.5 --label hf  --no-fit 
+         else
+             python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pfcomp -p electron,photon,pizero -g  --ymax 2.5 --ymaxRes 0.6 --ptmax 80 -E 3.0
+             python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pfcomp -p pion,klong,pimix       -g  --ymax 2.5 --ymaxRes 1.5 --ptmax 80 -E 3.0
+             python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pfcomp -p pion,pizero,pimix      -g  --ymax 3.0 --ymaxRes 1.5 --ptmax 80 --eta 3.0 5.0 --label hf  --no-fit 
          fi;
          ;;
     plots-pfold)

--- a/NtupleProducer/python/scripts/jetHtSuite.py
+++ b/NtupleProducer/python/scripts/jetHtSuite.py
@@ -408,6 +408,12 @@ for plotkind in options.plots.split(","):
           leg.Draw()
           
           c1.Print('%s/%s%s.png' % (odir, plotname, ("_"+options.label) if options.label else ""))
+          fout = ROOT.TFile.Open('%s/%s%s.root' % (odir, plotname, ("_"+options.label) if options.label else ""), "RECREATE")
+          fout.WriteTObject(frame,"frame")
+          for n,p in plots: 
+              p.SetTitle(n)
+              fout.WriteTObject(p)
+          fout.Close()
           del frame
 
 

--- a/NtupleProducer/python/scripts/objMultiplicityPlot.py
+++ b/NtupleProducer/python/scripts/objMultiplicityPlot.py
@@ -13,19 +13,20 @@ from optparse import OptionParser
 parser = OptionParser("%(prog) infile [ src [ dst ] ]")
 parser.add_option("--cl", type=float, dest="cl", default=0, help="Compute number to avoid truncations at this CL")
 parser.add_option("-p", type="string", dest="particles", action="append", default=[], help="objects to count")
-parser.add_option("-d", dest="detector", choices=["l1pfProducerBarrel","l1pfProducerHF","l1pfProducerHGCal","l1pfProducerHGCalNoTK"], default="l1pfProducerBarrel", help="choice of detector: l1pfProducerBarrel, l1pfProducerHGCal, l1pfProducerHGCalNoTK, l1pfProducerHF")
+parser.add_option("-d", dest="detector", choices=["Barrel","HF","HGCal","HGCalNoTK"], default="Barrel", help="choice of detector: Barrel, HGCal, HGCalNoTK, HF")
 options, args = parser.parse_args()
 if options.cl == 0:
-    odir = args[1] # "plots/910pre2/test"
+    odir = args[1] 
     os.system("mkdir -p "+odir)
     os.system("cp %s/src/FastPUPPI/NtupleProducer/python/display/index.php %s/" % (os.environ['CMSSW_BASE'], odir));
     ROOT.gROOT.ProcessLine(".x %s/src/FastPUPPI/NtupleProducer/python/display/tdrstyle.cc" % os.environ['CMSSW_BASE']);
 elif options.cl >= 1:
     raise RuntimeError("--cl must take an argument stricly between 0 and 1")
+
 c1 = ROOT.TCanvas("c1","c1")
 particles = [ "Calo", "EmCalo", "Mu", "TK" ]
-detector = options.detector
-detectorLabel = options.detector.replace('l1pfProducer','')
+detectorLabel = options.detector
+detectorFull = 'l1pfProducer' + options.detector
 for Algo in "PF", "Puppi":
     particles.append(Algo)
     for Type in "Charged Neutral ChargedHadron NeutralHadron Photon Electron Muon".split():
@@ -36,7 +37,7 @@ ROOT.gStyle.SetOptStat("omr")
 for particle in particles:
     if options.particles and (particle not in options.particles): continue
     if options.cl > 0:
-        n = tree.Draw("min(%smaxNL1%s,199)>>htemp(200,-0.5,199.5)" % (detector,particle), "mc_id == 998", "")
+        n = tree.Draw("min(%smaxNL1%s,199)>>htemp(200,-0.5,199.5)" % (detectorFull,particle), "mc_id == 998", "")
         if not n: continue
         h = ROOT.gROOT.FindObject("htemp")
         acc = 0
@@ -47,8 +48,8 @@ for particle in particles:
                 break
     else:
         for x in "tot","max":
-            print "%s%sNL1%s" % (detector, x, particle)
-            n = tree.Draw("%s%sNL1%s" % (detector, x, particle), "mc_id == 998", "")
+            print "plotting %s%sNL1%s" % (detectorFull, x, particle)
+            n = tree.Draw("%s%sNL1%s" % (detectorFull, x, particle), "mc_id == 998", "")
             h = ROOT.gROOT.FindObject("htemp")
             if x=='tot':
                 h.GetXaxis().SetTitle("Total %s in %s"%(particle, detectorLabel))
@@ -57,16 +58,18 @@ for particle in particles:
             h.GetYaxis().SetTitle("Events")
             h.Draw()
             if not n: continue
-            out = odir+'/'+particle+"_"+detector+"_"+x+".pdf"
-            c1.Print(out)
-        print "%svecNL1%s" % (detector, particle)
-        n = tree.Draw("%svecNL1%s" % (detector, particle), "mc_id == 998", "")
+            for ext in "pdf","png":
+                out = odir+'/'+particle+"_"+detectorLabel+"_"+x+"."+ext
+                c1.Print(out)
+        print "plotting %svecNL1%s" % (detectorFull, particle)
+        n = tree.Draw("%svecNL1%s" % (detectorFull, particle), "mc_id == 998", "")
         h = ROOT.gROOT.FindObject("htemp")
         h.GetXaxis().SetTitle("%s in %s region"%(particle, detectorLabel))
         h.GetYaxis().SetTitle("Regions")
         h.Draw()
         c1.SetLogy()
         if not n: continue
-        out = odir+'/'+particle+"_"+detector+"_vec.pdf"
-        c1.Print(out)
+        for ext in "pdf","png":
+            out = odir+'/'+particle+"_"+detectorLabel+"_vec."+ext
+            c1.Print(out)
             

--- a/NtupleProducer/python/scripts/objMultiplicityPlot.py
+++ b/NtupleProducer/python/scripts/objMultiplicityPlot.py
@@ -13,6 +13,7 @@ from optparse import OptionParser
 parser = OptionParser("%(prog) infile [ src [ dst ] ]")
 parser.add_option("--cl", type=float, dest="cl", default=0, help="Compute number to avoid truncations at this CL")
 parser.add_option("-p", type="string", dest="particles", action="append", default=[], help="objects to count")
+parser.add_option("-d", dest="detector", choices=["l1pfProducerBarrel","l1pfProducerHF","l1pfProducerHGCal"], default="l1pfProducerBarrel", help="choice of detector")
 options, args = parser.parse_args()
 if options.cl == 0:
     odir = args[1] # "plots/910pre2/test"
@@ -23,6 +24,7 @@ elif options.cl >= 1:
     raise RuntimeError("--cl must take an argument stricly between 0 and 1")
 c1 = ROOT.TCanvas("c1","c1")
 particles = [ "Calo", "EmCalo", "Mu", "TK" ]
+detector = options.detector
 for Algo in "PF", "Puppi":
     particles.append(Algo)
     for Type in "Charged Neutral ChargedHadron NeutralHadron Photon Electron Muon".split():
@@ -33,7 +35,7 @@ ROOT.gStyle.SetOptStat("omr")
 for particle in particles:
     if options.particles and (particle not in options.particles): continue
     if options.cl > 0:
-        n = tree.Draw("min(maxNL1%s,199)>>htemp(200,-0.5,199.5)" % (particle), "mc_id == 998", "")
+        n = tree.Draw("min(%smaxNL1%s,199)>>htemp(200,-0.5,199.5)" % (detector,particle), "mc_id == 998", "")
         if not n: continue
         h = ROOT.gROOT.FindObject("htemp")
         acc = 0
@@ -44,9 +46,9 @@ for particle in particles:
                 break
     else:
         for x in "tot","max":
-            print "%sNL1%s" % (x, particle)
-            n = tree.Draw("%sNL1%s" % (x, particle), "mc_id == 998", "")
+            print "%s%sNL1%s" % (detector, x, particle)
+            n = tree.Draw("%s%sNL1%s" % (detector, x, particle), "mc_id == 998", "")
             if not n: continue
-            out = odir+'/'+particle+"_"+x+".png"
+            out = odir+'/'+particle+"_"+detector+"_"+x+".png"
             c1.Print(out)
 

--- a/NtupleProducer/python/scripts/prun.sh
+++ b/NtupleProducer/python/scripts/prun.sh
@@ -1,6 +1,9 @@
 CODE=${1/.py/}; shift
 MAIN=/eos/cms/store/cmst3/group/l1tr/gpetrucc/106X/NewInputs104X/240719.done/$1
 PREFIX="inputs104X_"
+N=8
+
+if [[ "$1" == "-j" ]]; then N=$2; shift; shift; fi;
 
 if [[ "$1" == "--v1" ]]; then # this is the default but we keep anyway
     shift;
@@ -10,10 +13,29 @@ elif [[ "$1" == "--v1_fat" ]]; then # this is the default but we keep anyway
     shift;
     MAIN=/eos/cms/store/cmst3/group/l1tr/gpetrucc/106X/NewInputs104X/240719_fat.done/$1
     PREFIX="inputs104X_"
+elif [[ "$1" == "--v2_fat" ]]; then # this is the default but we keep anyway
+    shift;
+    MAIN=/eos/cms/store/cmst3/group/l1tr/gpetrucc/106X/NewInputs104X/240719_newhgc_try2_fat.done/$1
+    PREFIX="inputs104X_"
+elif [[ "$1" == "--v3_fat" ]]; then # this is the default but we keep anyway
+    shift;
+    MAIN=/eos/cms/store/cmst3/group/l1tr/gpetrucc/106X/NewInputs104X/300819_hgcv3_fat.done/$1
+    PREFIX="inputs104X_"
 elif [[ "$1" == "--v0" ]]; then # this is the default but we keep anyway
     shift;
     MAIN=/eos/cms/store/cmst3/group/l1tr/gpetrucc/106X/NewInputs104X/240719_oldhgc.done/$1
     PREFIX="inputs104X_"
+elif [[ "$1" == "--106X_v0" ]]; then # this is the default but we keep anyway
+    shift;
+    MAIN=/eos/cms/store/cmst3/group/l1tr/gpetrucc/106X/NewInputs106X/250819.done/$1
+    PREFIX="inputs106X_"
+    if echo $CODE | grep -q 106X; then
+        echo "Assume $CODE is ready for 106X";
+    else
+        echo "Convert ${CODE}.py to ${CODE/_104X/}_106X.py automatically updating era and geometry";
+        sed -e 's+Phase2C4+Phase2C8+g' -e 's+GeometryExtended2023D35+GeometryExtended2023D41+' ${CODE}.py > ${CODE/_104X/}_106X.py;
+        CODE=${CODE/_104X/}_106X
+    fi
 fi;
  
 if [[ "$L1TPF_LOCAL_INPUT_DIR" != "" ]] && test -d $L1TPF_LOCAL_INPUT_DIR; then
@@ -39,7 +61,7 @@ if [[ "$1" == "--noclean" ]]; then
 fi
 
 PSCRIPT=$CMSSW_BASE/src/FastPUPPI/NtupleProducer/python/scripts/
-$PSCRIPT/cmsSplit.pl --files "$MAIN/${PREFIX}*${INPUT}*root" --label ${OUTPUT} ${CODE}.py --bash --n 8 $* && bash ${CODE}_${OUTPUT}_local.sh 
+$PSCRIPT/cmsSplit.pl --files "$MAIN/${PREFIX}*root" --label ${OUTPUT} ${CODE}.py --bash --n $N $* && bash ${CODE}_${OUTPUT}_local.sh 
 
 if $clean; then
     REPORT=$(grep -o "tee \S\+_${OUTPUT}.report.txt" ${CODE}_${OUTPUT}_local.sh  | awk '{print $2}');

--- a/NtupleProducer/python/scripts/prun.sh
+++ b/NtupleProducer/python/scripts/prun.sh
@@ -1,13 +1,21 @@
 CODE=${1/.py/}; shift
-MAIN=/eos/cms/store/cmst3/user/gpetrucc/l1tr/105X/NewInputs104X/010319/$1
+MAIN=/eos/cms/store/cmst3/group/l1tr/gpetrucc/106X/NewInputs104X/240719.done/$1
 PREFIX="inputs104X_"
 
-if [[ "$1" == "--v3" ]]; then # this is the default but we keep anyway
+if [[ "$1" == "--v1" ]]; then # this is the default but we keep anyway
     shift;
-    MAIN=/eos/cms/store/cmst3/user/gpetrucc/l1tr/105X/NewInputs104X/010319/$1
+    MAIN=/eos/cms/store/cmst3/group/l1tr/gpetrucc/106X/NewInputs104X/240719.done/$1
+    PREFIX="inputs104X_"
+elif [[ "$1" == "--v1_fat" ]]; then # this is the default but we keep anyway
+    shift;
+    MAIN=/eos/cms/store/cmst3/group/l1tr/gpetrucc/106X/NewInputs104X/240719_fat.done/$1
+    PREFIX="inputs104X_"
+elif [[ "$1" == "--v0" ]]; then # this is the default but we keep anyway
+    shift;
+    MAIN=/eos/cms/store/cmst3/group/l1tr/gpetrucc/106X/NewInputs104X/240719_oldhgc.done/$1
     PREFIX="inputs104X_"
 fi;
-
+ 
 if [[ "$L1TPF_LOCAL_INPUT_DIR" != "" ]] && test -d $L1TPF_LOCAL_INPUT_DIR; then
     L1TPF_LOCAL_MAIN=$L1TPF_LOCAL_INPUT_DIR/$(basename $(dirname $MAIN))/$(basename $MAIN)
     if test -d $L1TPF_LOCAL_MAIN; then

--- a/NtupleProducer/python/scripts/prun.sh
+++ b/NtupleProducer/python/scripts/prun.sh
@@ -1,27 +1,15 @@
+#!/bin/bash
 CODE=${1/.py/}; shift
-MAIN=/eos/cms/store/cmst3/group/l1tr/gpetrucc/106X/NewInputs104X/240719.done/$1
-PREFIX="inputs104X_"
-N=8
 
+if [[ "$CODE" == "" || "$CODE" == "--help" || "$CODE" == "-h" || "$CODE" == "-?" ]]; then
+    echo "scripts/prun.sh config.py [-j <N>] --<version>  <Sample> <OutputName> [ --noclean ] [ --inline-customize \"<options>\" ]"
+    exit 0;
+fi
+
+N=8
 if [[ "$1" == "-j" ]]; then N=$2; shift; shift; fi;
 
-if [[ "$1" == "--v1" ]]; then # this is the default but we keep anyway
-    shift;
-    MAIN=/eos/cms/store/cmst3/group/l1tr/gpetrucc/106X/NewInputs104X/240719.done/$1
-    PREFIX="inputs104X_"
-elif [[ "$1" == "--v1_fat" ]]; then # this is the default but we keep anyway
-    shift;
-    MAIN=/eos/cms/store/cmst3/group/l1tr/gpetrucc/106X/NewInputs104X/240719_fat.done/$1
-    PREFIX="inputs104X_"
-elif [[ "$1" == "--v2_fat" ]]; then # this is the default but we keep anyway
-    shift;
-    MAIN=/eos/cms/store/cmst3/group/l1tr/gpetrucc/106X/NewInputs104X/240719_newhgc_try2_fat.done/$1
-    PREFIX="inputs104X_"
-elif [[ "$1" == "--v3_fat" ]]; then # this is the default but we keep anyway
-    shift;
-    MAIN=/eos/cms/store/cmst3/group/l1tr/gpetrucc/106X/NewInputs104X/300819_hgcv3_fat.done/$1
-    PREFIX="inputs104X_"
-elif [[ "$1" == "--v0" ]]; then # this is the default but we keep anyway
+if [[ "$1" == "--v0" ]]; then # this is the default but we keep anyway
     shift;
     MAIN=/eos/cms/store/cmst3/group/l1tr/gpetrucc/106X/NewInputs104X/240719_oldhgc.done/$1
     PREFIX="inputs104X_"
@@ -36,6 +24,16 @@ elif [[ "$1" == "--106X_v0" ]]; then # this is the default but we keep anyway
         sed -e 's+Phase2C4+Phase2C8+g' -e 's+GeometryExtended2023D35+GeometryExtended2023D41+' ${CODE}.py > ${CODE/_104X/}_106X.py;
         CODE=${CODE/_104X/}_106X
     fi
+elif [[ "$1" == "--v3_fat" ]]; then # this is the default but we keep anyway
+    shift;
+    MAIN=/eos/cms/store/cmst3/group/l1tr/gpetrucc/106X/NewInputs104X/300819_hgcv3_fat.done/$1
+    PREFIX="inputs104X_"
+else 
+    echo "You mush specify the version of the input samples to run on "
+    echo "   --v0      : 104X MDT MC inputs, with default 106X HGCal TPs "
+    echo "   --106X_v0 : 106X L1T MC inputs, with default 106X HGCal TPs "
+    echo "   --v3_fat  : 104X MDT MC inputs, with experimental HGCal TPs, and inputs for re-running HGCal 3D clustering"
+
 fi;
  
 if [[ "$L1TPF_LOCAL_INPUT_DIR" != "" ]] && test -d $L1TPF_LOCAL_INPUT_DIR; then

--- a/NtupleProducer/python/scripts/respPlots.py
+++ b/NtupleProducer/python/scripts/respPlots.py
@@ -280,7 +280,7 @@ whats = [
         ("Puppi",      "L1OldPuppi$",   ROOT.kAzure+1, 20, 1.5),
         ("Puppi4MET",  "L1OldPuppiForMET$",   ROOT.kAzure+2, 20, 1.1),
     ]),
-    ('l1pfnew',[
+    ('l1pf',[
         ("Gen #times Acc",        "GenAcc$",    ROOT.kGray+1,  20, 1.2),
         ("Raw Calo",   "L1RawBarrelCalo$+L1RawHGCal$", ROOT.kViolet-4,  21, 1.7),
         ("Ecal",       "L1BarrelEcal$+L1RawHGCalEM$",    ROOT.kGreen+1,  21, 1.7),
@@ -288,13 +288,13 @@ whats = [
         ("TK",         "L1TK$",      ROOT.kRed+0, 20, 1.2),
         ("PF",         "L1PF$",      ROOT.kOrange+7, 20, 1.2),
     ]),
-    ('l1pfnewpu',[
+    ('l1pfpu',[
         ("Gen #times Acc",        "GenAcc$",    ROOT.kGray+1,  20, 1.2),
         ("Calo",       "L1Calo$",     ROOT.kViolet+1, 21, 1.5),
         ("TK #Deltaz", "L1TKV5$",     ROOT.kOrange-7, 34, 1.2),
         ("PF",         "L1PF$",       ROOT.kOrange+7, 21, 1.5),
         ("PFCHS",      "L1CHS$",      ROOT.kMagenta-6, 21, 1.2),
-        ("PuppiOld",   "L1PuppiOld$", ROOT.kGreen+2, 20, 1.5),
+        #("PuppiOld",   "L1PuppiOld$", ROOT.kGreen+2, 20, 1.5),
         ("Puppi",      "L1Puppi$",    ROOT.kRed+1, 20, 1.1),
     ]),
     ('l1pfcomp',[

--- a/NtupleProducer/python/scripts/respPlots.py
+++ b/NtupleProducer/python/scripts/respPlots.py
@@ -246,16 +246,16 @@ whats = [
         ("Corr",  "L1BarrelEcal$",             ROOT.kAzure+2,  20, 1.0),
     ]),
     ('debug-hf',[
-        ("Cells",  "L1RawHFCells$",  ROOT.kGreen+2,  20, 1.1),
-        ("Raw",  "L1RawHFCalo$",     ROOT.kAzure+1,  25, 2.0),
-        ("Corr",  "L1HFCalo$",       ROOT.kAzure+2,  21, 1.6),
+        #("Cells",  "L1RawHFCells$",  ROOT.kGreen+2,  20, 1.1),
+        ("Raw",  "L1RawHFCalo$",     ROOT.kRed+1,    21, 1.6),
+        ("Corr",  "L1HFCalo$",       ROOT.kAzure+2,  20, 1.0),
     ]),
     ('debug-hcal',[
-        ("Raw",   "L1RawBarrelCalo$",   ROOT.kAzure+2,  21, 1.6),
-        ("UncOnly",   "L1RawBarrelCaloUnclust$",   ROOT.kRed-7,    21, 1.4),
+        ("Raw",   "L1RawBarrelCalo$",   ROOT.kRed+1,  21, 1.6),
+        #("UncOnly",   "L1RawBarrelCaloUnclust$",   ROOT.kRed-7,    21, 1.4),
         ("Corr",  "L1BarrelCalo$",      ROOT.kAzure+2,  20, 1.0),
         ("RawEM", "L1RawBarrelCaloEM$", ROOT.kViolet+1, 20, 0.9),
-        ("EM_UncOnly", "L1RawBarrelCaloEMUnclust$", ROOT.kRed+2,    20, 0.9),
+        #("EM_UncOnly", "L1RawBarrelCaloEMUnclust$", ROOT.kRed+2,    20, 0.9),
     ]),
     ('debug-hgc',[
         ("Raw",     "L1RawHGCal$",   ROOT.kGreen+2,   25, 2.0),
@@ -282,7 +282,7 @@ whats = [
     ]),
     ('l1pf',[
         ("Gen #times Acc",        "GenAcc$",    ROOT.kGray+1,  20, 1.2),
-        ("Raw Calo",   "L1RawBarrelCalo$+L1RawHGCal$", ROOT.kViolet-4,  21, 1.7),
+        ("Raw Calo",   "L1RawBarrelCalo$+L1RawHGCal$+L1RawHFCalo$", ROOT.kViolet-4,  21, 1.7),
         ("Ecal",       "L1BarrelEcal$+L1RawHGCalEM$",    ROOT.kGreen+1,  21, 1.7),
         ("Calo",       "L1Calo$",    ROOT.kViolet+2, 34, 1.5),
         ("TK",         "L1TK$",      ROOT.kRed+0, 20, 1.2),

--- a/NtupleProducer/python/scripts/respPlots.py
+++ b/NtupleProducer/python/scripts/respPlots.py
@@ -650,5 +650,11 @@ if __name__ == "__main__":
                     leg.Draw()
                     out = odir+'/'+oname+pfix+"-"+kind+"_"+ptdef+".png"
                     c1.Print(out)
+                    fout = ROOT.TFile.Open(odir+'/'+oname+pfix+"-"+kind+"_"+ptdef+".root", "RECREATE")
+                    fout.WriteTObject(frame,"frame")
+                    for n,p in plots: 
+                        p.SetTitle(n)
+                        fout.WriteTObject(p)
+                    fout.Close()
                     del frame
 

--- a/NtupleProducer/python/scripts/stackPlotsFromFiles.py
+++ b/NtupleProducer/python/scripts/stackPlotsFromFiles.py
@@ -1,0 +1,99 @@
+import os, re, sys
+import ROOT
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+ROOT.gROOT.SetBatch(True)
+ROOT.gStyle.SetOptStat(False)
+ROOT.gStyle.SetErrorX(0.5)
+ROOT.gErrorIgnoreLevel = ROOT.kWarning
+
+
+from optparse import OptionParser
+parser = OptionParser("%(prog) out what [name1=]file1[,color1]  [name1=]file2[,color2] ...  ")
+parser.add_option("--logy", dest="logy", action="store_false", default=False, help="Log y axis")
+parser.add_option("--liny", dest="logy", action="store_false", default=False, help="Linear y axis")
+parser.add_option("--legend", dest="legend", default="BR", help="Legend placement: BR, TR")
+#parser.add_option("-W", dest="what_reg",     default=None, help="Choose set (inputs, l1pf, ...)")
+#parser.add_option("-P","--plots", dest="plots", default="rate,isorate,roc,effc", help="Choose plot or comma-separated list of plots")
+#parser.add_option("-J","--jets", dest="jets", default="ak4", help="Choose jet flavour")
+#parser.add_option("-j","--jecs", dest="jecs", default="jecs.root", help="Choose JEC file")
+#parser.add_option("--jm","--jec-method", dest="jecMethod", default="", help="Choose JEC method")
+#parser.add_option("-R","--raw", dest="rawJets", default=False, action="store_true", help="Don't appy JECs")
+#parser.add_option("-s", dest="genht",  default=None, type="float", help="Choose gen ht")
+#parser.add_option("-r", dest="rate",  default="10,20,50", type="string", help="Choose rate [kHz] (for isorate plots, can specify more than one)")
+#parser.add_option("-l","--label", dest="label",  default=None, type="string", help="Extra label for plots")
+#parser.add_option("-p", "--pt", dest="pt",  default=30, type="float", help="Choose pt cut")
+#parser.add_option("-e", "--eta", dest="eta",  default=2.4, type="float", help="Choose eta")
+#parser.add_option("-v", dest="var",  default="ht", help="Choose variable (ht, met, metCentral, mht, jet<N>, mjj, ptj-mjj<M>)")
+#parser.add_option("--xlabel","--varlabel", dest="varlabel", default=None, help="X axis label for the variable")
+#parser.add_option("--xmax", dest="xmax",  default=None, type=float, help="Choose variable")
+#parser.add_option("--logxbins", dest="logxbins",  default=None, nargs=2, type=float, help="--logxbins N X will make N bins, the last being a factor X larger than the first")
+options, args = parser.parse_args()
+
+if len(args) < 4:
+    parser.print_usage()
+    sys.exit(1)
+
+colors = [ ROOT.kBlack, ROOT.kRed, ROOT.kGreen+2, ROOT.kBlue, ROOT.kMagenta+1, ROOT.kOrange+7, ROOT.kCyan+1, ROOT.kGray+2, ROOT.kViolet+5, ROOT.kSpring+5, ROOT.kAzure+1, ROOT.kPink+7, ROOT.kOrange+3, ROOT.kBlue+3, ROOT.kMagenta+3, ROOT.kRed+2 ]; colors.reverse()
+tfiles = []
+tobjs = []
+labels = []
+frame = None
+for i,fname in enumerate(args[2:]):
+    if "," in fname:
+        (fname,colorname) = fname.split(",")
+        color = eval("ROOT.k"+colorname)
+    else:
+        color = colors.pop()
+    if "=" in fname: 
+        (name, fname) = fname.split("=")
+    else: 
+        name = fname.replace(".root","")
+    tfile = ROOT.TFile.Open(fname)
+    if not tfile: 
+        print "ERROR opening %s" % tfile
+        continue
+    tobj = tfile.Get(args[1])
+    if not tobj:
+        print "ERROR fetching %r from %s" % (args[1], tfile)
+        tfile.ls()
+        continue
+    if not frame:
+        frame = tfile.Get("frame")
+        if not frame:
+            print "ERROR fetching %r from %s" % ("frame", tfile)
+            tfile.ls()
+    tfiles.append(tfile)
+    tobjs.append(tobj)
+    labels.append(name)
+    tobj.SetLineColor(color)
+    tobj.SetMarkerColor(color)
+if not tobjs:
+    print "Nothing to plot!"
+    sys.exit(1)
+
+odir = os.path.dirname(args[0])
+if odir:
+    if not os.path.isdir(odir):
+        os.system("mkdir -p "+odir)
+    os.system("cp %s/src/FastPUPPI/NtupleProducer/python/display/index.php %s/" % (os.environ['CMSSW_BASE'], odir));
+ROOT.gROOT.ProcessLine(".x %s/src/FastPUPPI/NtupleProducer/python/display/tdrstyle.cc" % os.environ['CMSSW_BASE']);
+ROOT.gStyle.SetOptStat(0)
+ROOT.gStyle.SetOptFit(0)
+c1 = ROOT.TCanvas("c1","c1")
+
+c1.SetLogy(options.logy)
+if options.legend == "TR":
+    leg = ROOT.TLegend(0.6,0.99,0.95,0.99-0.06*len(labels))
+elif options.legend == "BR":
+    leg = ROOT.TLegend(0.6,0.19,0.95,0.19+0.06*len(labels))
+else:
+    raise RuntimeError("Unsupported legend option %r" % options.legend)
+
+frame.Draw()
+for n,p in zip(labels,tobjs): 
+    p.Draw("PCX SAME" if ("TH1" not in p.ClassName()) else "C SAME")
+    leg.AddEntry(p, n, "LP")
+leg.Draw()
+
+c1.Print(args[0])
+print "Wrote %s" % args[0]

--- a/NtupleProducer/python/scripts/valSuite.sh
+++ b/NtupleProducer/python/scripts/valSuite.sh
@@ -67,9 +67,9 @@ case $W in
          ;;
     run-jets)
          python runPerformanceNTuple.py || exit 1;
-         for X in {TTbar,VBF_HToInvisible,SingleNeutrino}_PU200; do
+         for X in {TTbar,VBF_HToInvisible}_PU200; do
              ./scripts/prun.sh runPerformanceNTuple.py  $SAMPLES $X ${X}.${V}  --inline-customize 'addCHS();addTKs()';
-             break 
+             #break 
          done
          ;;
     plot-jets)
@@ -85,12 +85,6 @@ case $W in
          python runPerformanceNTuple.py || exit 1;
          for X in {TTbar,VBF_HToInvisible,SingleNeutrino}_PU200; do
              ./scripts/prun.sh runPerformanceNTuple.py  $SAMPLES $X ${X}.${V}  --inline-customize 'addCHS();addTKs()';
-         done
-         ;;
-    run-rates-v1)
-         python runPerformanceNTuple.py || exit 1;
-         for X in {TTbar,VBF_HToInvisible,SingleNeutrino}_PU200; do
-             ./scripts/prun.sh runPerformanceNTuple.py  $SAMPLES $X ${X}.${V}  --inline-customize 'addCHS();addTKs();gov1()';
          done
          ;;
     plot-rates)
@@ -125,8 +119,18 @@ case $W in
              python scripts/stackPlotsFromFiles.py --legend="TR" $me/${plot}-comp-${W}.png ${W}_eff  v0=$v0/$plot.root,Azure+2 ${V}=$me/$plot.root,Green+2;
          done
          X=VBF_HToInvisible_PU200; 
-         #python scripts/jetHtSuite.py perfNano_${X}.${V}.root perfNano_SingleNeutrino_PU200.${V}.root $PLOTDIR/ht/$X -j jecs.${V}.root -w l1pfpu -v jet2       --eta 4.7
-         #python scripts/jetHtSuite.py perfNano_${X}.${V}.root perfNano_SingleNeutrino_PU200.${V}.root $PLOTDIR/ht/$X -j jecs.${V}.root -w l1pfpu -v ptj-mjj620 --eta 4.7
+         ;;
+    run-mult)
+         python runPerformanceNTuple.py || exit 1;
+         X=TTbar_PU200; 
+         ./scripts/prun.sh runPerformanceNTuple.py  $SAMPLES $X ${X}.${V}_regional  --inline-customize 'respOnly();goRegional()';
+         ;;
+    plot-mult)
+         python runPerformanceNTuple.py || exit 1;
+         X=TTbar_PU200; 
+         for D in Barrel HGCal HGCalNoTK HF; do
+             python scripts/objMultiplicityPlot.py perfTuple_${X}.${V}_regional.root  $PLOTDIR/multiplicities/${X} -d $D
+         done;
          ;;
 
 esac;

--- a/NtupleProducer/python/scripts/valSuite.sh
+++ b/NtupleProducer/python/scripts/valSuite.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+V="$1"; shift
+PLOTDIR="plots/106X/from104X/${V}/val"
+SAMPLES="--$V";
+[[ "$V" == "v2" ]] && SAMPLES="--v2_fat"
+[[ "$V" == "v3" ]] && SAMPLES="--v3_fat"
+
+W=$1; shift;
+case $W in
+    run-pgun)
+         #SAMPLES="--v1_fat";
+         python runRespNTupler.py || exit 1;
+         for PU in PU200; do #PU0
+             for X in Particle{Gun,GunPt0p5To5,GunPt80To300}_${PU}; do 
+                 ./scripts/prun.sh  runRespNTupler.py $SAMPLES $X ${X}.${V}  --inline-customize 'goGun()'; 
+                 grep -q '^JOBS:.*, 0 passed' respTupleNew_${X}.${V}.report.txt && echo " === ERROR. Will stop here === " && exit 2;
+             done
+         done
+         ;;
+    plot-pgun)
+         for PU in PU200; do
+             NTUPLES=$(ls respTupleNew_Particle{Gun,GunPt0p5To5,GunPt80To300}_${PU}.${V}.root);
+             if [[ "$PU" == "PU0" ]]; then
+                 #python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p electron,photon,pizero -g  --ymaxRes 0.35 --ptmax 150 -E 3.0
+                 #python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p pion,klong,pimix       -g  --ymaxRes 1.2  --ptmax 150 -E 3.0
+                 python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p pion,pizero,pimix      -g  --eta 3.0 5.0  --ymax 3 --ymaxRes 1.5 --label hf  --no-fit 
+             else
+                 python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p electron,photon,pizero -g  --ymax 2.5 --ymaxRes 0.6 --ptmax 80 -E 3.0
+                 python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p pion,klong,pimix       -g  --ymax 2.5 --ymaxRes 1.5 --ptmax 80 -E 3.0
+                 python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p pion,pizero,pimix      -g  --ymax 3.0 --ymaxRes 1.5 --ptmax 80 --eta 3.0 5.0 --label hf  --no-fit 
+             fi;
+         done
+         ;;
+    diff-pgun-nopu)
+         X=ParticleGun_PU0
+         f104v0=plots/106X/from104X/v0/val/${X}; 
+         me=$PLOTDIR/${X}; 
+         for X in pion photon; do for PT in ptbest pt02; do 
+            for W in PF Calo; do for G in _gauss; do for R in "" _res; do for E in 13_17 25_30; do #  17_25
+                plot=${X}_eta_${E}${R}${G}-l1pf_${PT}
+                python scripts/stackPlotsFromFiles.py --legend="TR" $me/${plot}-comp-${W}.png ${W}${G}${R} v0=$f104v0/$plot.root,Azure+2 ${V}=$me/$plot.root,Green+2;
+            done; done; done; done;
+         done; done
+         ;;
+    run-jets-nopu)
+         python runPerformanceNTuple.py || exit 1;
+         for X in TTbar_PU0; do
+             ./scripts/prun.sh runPerformanceNTuple.py  $SAMPLES $X ${X}.${V}  --inline-customize 'addCHS();addTKs()'; 
+         done
+         ;;
+    plot-jets-nopu)
+         for X in TTbar_PU0; do
+            python scripts/respPlots.py perfTuple_${X}.${V}.root $PLOTDIR/${X} -w l1pf -p jet -g
+            #python scripts/respPlots.py perfTuple_${X}.${V}.root $PLOTDIR/${X} -w l1pf -p jet -g --eta 3.5 4.5 --ptmax 100
+         done
+         ;;
+    diff-jets-nopu)
+         for X in TTbar_PU0; do
+            f104v0=plots/106X/from104X/v0/val/${X}; 
+            me=$PLOTDIR/${X}; PT="pt"; X="jet"; 
+            for W in PF Calo; do for G in "" _gauss; do for R in "" _res; do for E in 13_17 17_25 25_30; do
+                    plot=${X}_eta_${E}${R}${G}-l1pf_${PT}
+                    python scripts/stackPlotsFromFiles.py --legend="TR" $me/${plot}-comp-${W}.png ${W}${G}${R} v0=$f104v0/$plot.root,Azure+2 ${V}=$me/$plot.root,Green+2;
+            done; done; done; done;
+         done
+         ;;
+    run-jets)
+         python runPerformanceNTuple.py || exit 1;
+         for X in {TTbar,VBF_HToInvisible,SingleNeutrino}_PU200; do
+             ./scripts/prun.sh runPerformanceNTuple.py  $SAMPLES $X ${X}.${V}  --inline-customize 'addCHS();addTKs()';
+             break 
+         done
+         ;;
+    plot-jets)
+         #for X in {TTbar,VBF_HToInvisible}_PU200; do
+         X=TTbar_PU200
+             python scripts/respPlots.py perfTuple_${X}.${V}.root -p jet --no-eta -G $PLOTDIR/${X} -w l1pfpu --ymax 2.2 --ymaxRes 0.9 -E 3.0
+         X=VBF_HToInvisible_PU200
+             python scripts/respPlots.py perfTuple_${X}.${V}.root -p jet --no-eta -G $PLOTDIR/${X} -w l1pfpu --ymax 2.5 --ymaxRes 0.9 --eta 3.0 5.0 --ptmax 150
+             python scripts/respPlots.py perfTuple_${X}.${V}.root -p jet --no-eta -G $PLOTDIR/${X} -w l1pfpu --ymax 2.5 --ymaxRes 0.9 --eta 3.5 4.5 --ptmax 150
+         #done
+         ;;
+    run-rates)
+         python runPerformanceNTuple.py || exit 1;
+         for X in {TTbar,VBF_HToInvisible,SingleNeutrino}_PU200; do
+         #for X in VBF_HToInvisible_PU200; do
+             ./scripts/prun.sh runPerformanceNTuple.py  $SAMPLES $X ${X}.${V}  --inline-customize 'addCHS();addTKs()';
+         done
+         ;;
+    run-rates-v1)
+         python runPerformanceNTuple.py || exit 1;
+         for X in {TTbar,VBF_HToInvisible,SingleNeutrino}_PU200; do
+             ./scripts/prun.sh runPerformanceNTuple.py  $SAMPLES $X ${X}.${V}  --inline-customize 'addCHS();addTKs();gov1()';
+         done
+         ;;
+    plot-rates)
+         X=TTbar_PU200; Y=VBF_HToInvisible_PU200;
+         #python scripts/makeJecs.py perfNano_${X}.${V}.root perfNano_${Y}.${V}.root  -A  -o jecs.${V}.root 
+         for X in {TTbar,VBF_HToInvisible}_PU200; do 
+             python scripts/jetHtSuite.py perfNano_${X}.${V}.root perfNano_SingleNeutrino_PU200.${V}.root $PLOTDIR/met/$X -j jecs.${V}.root -w l1pfpu -v met --eta 5.0
+         done
+         X=TTbar_PU200; 
+         python scripts/jetHtSuite.py perfNano_${X}.${V}.root perfNano_SingleNeutrino_PU200.${V}.root $PLOTDIR/ht/$X -j jecs.${V}.root -w l1pfpu -v jet1 --eta 2.4
+         python scripts/jetHtSuite.py perfNano_${X}.${V}.root perfNano_SingleNeutrino_PU200.${V}.root $PLOTDIR/ht/$X -j jecs.${V}.root -w l1pfpu -v jet4 --eta 2.4
+         python scripts/jetHtSuite.py perfNano_${X}.${V}.root perfNano_SingleNeutrino_PU200.${V}.root $PLOTDIR/ht/$X -j jecs.${V}.root -w l1pfpu -v ht   --eta 2.4
+         python scripts/jetHtSuite.py perfNano_${X}.${V}.root perfNano_SingleNeutrino_PU200.${V}.root $PLOTDIR/ht/$X -j jecs.${V}.root -w l1pfpu -v ht   --eta 3.5
+         X=VBF_HToInvisible_PU200; 
+         python scripts/jetHtSuite.py perfNano_${X}.${V}.root perfNano_SingleNeutrino_PU200.${V}.root $PLOTDIR/ht/$X -j jecs.${V}.root -w l1pfpu -v jet2       --eta 4.7
+         python scripts/jetHtSuite.py perfNano_${X}.${V}.root perfNano_SingleNeutrino_PU200.${V}.root $PLOTDIR/ht/$X -j jecs.${V}.root -w l1pfpu -v ptj-mjj620 --eta 4.7
+         ;;
+esac;

--- a/NtupleProducer/python/scripts/valSuite106X.sh
+++ b/NtupleProducer/python/scripts/valSuite106X.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+V="106X_v0"; 
+PLOTDIR="plots/106X/from106X/${V/106X_v/v}/val"
+SAMPLES="--$V";
+
+W=$1; shift;
+case $W in
+    run-pgun)
+        bash scripts/doRespCorrs106X.sh rerun
+        ;;
+    plot-pgun)
+         for PU in PU0 PU200; do
+             NTUPLES=$(ls respTupleNew_{SinglePion_PT0to200,SinglePion_PT2to100,SinglePion0_FlatPt-8to100,PhotonFlatPt8To150,Mu_FlatPt2to100}_${PU}.${V}.root);
+             if [[ "$PU" == "PU0" ]]; then
+                 python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p electron,photon,pizero -g  --ymaxRes 0.35 --ptmax 150 -E 3.0
+                 python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p pion,klong,pimix       -g  --ymaxRes 1.2  --ptmax 150 -E 3.0
+                 python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p pion,pizero,pimix      -g  --eta 3.0 5.0  --ymax 3 --ymaxRes 1.5 --label hf  --no-fit 
+             else
+                 python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p electron,photon,pizero -g  --ymax 2.5 --ymaxRes 0.6 --ptmax 80 -E 3.0
+                 python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p pion,klong,pimix       -g  --ymax 2.5 --ymaxRes 1.5 --ptmax 80 -E 3.0
+                 python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p pion,pizero,pimix      -g  --ymax 3.0 --ymaxRes 1.5 --ptmax 80 --eta 3.0 5.0 --label hf  --no-fit 
+             fi;
+         done
+         ;;
+    run-jets-nopu)
+         python runPerformanceNTuple.py || exit 1;
+         for X in TTbar_PU0; do
+             ./scripts/prun.sh runPerformanceNTuple.py  $SAMPLES $X ${X}.${V}  --inline-customize 'addCHS();addTKs();addCalib()'; 
+         done
+         ;;
+    plot-jets-nopu)
+         for X in TTbar_PU0; do
+            #python scripts/respPlots.py perfTuple_${X}.${V}.root $PLOTDIR/${X} -w l1pf -p jet -g
+            #python scripts/respPlots.py perfTuple_${X}.${V}.root $PLOTDIR/${X} -w l1pf -p jet -g --eta 3.5 4.5 --no-eta --ptmax 100 
+            f104v0=plots/106X/from104X/v0/val/${X}
+            me=$PLOTDIR/${X}
+            PT="pt"; X="jet"; 
+            #for W in PF Calo; do for G in "" _gauss; do for R in "" _res; do for E in 00_13 13_17 17_25 25_30 30_50 35_45; do
+            for W in PF Calo; do for G in "" _gauss; do for R in "" _res; do for E in 35_45; do
+                    plot=${X}_eta_${E}${R}${G}-l1pf_${PT}
+                    python scripts/stackPlotsFromFiles.py --legend="TR" $me/${plot}-comp-${W}.png ${W}${G}${R} MTD_MC=$f104v0/$plot.root,Azure+2 L1T_MC=$me/$plot.root,Green+2;
+            done; done; done; done;
+         done
+         ;;
+    run-jets)
+         python runPerformanceNTuple.py || exit 1;
+         for X in {,VBF_HToInvisible,SingleNeutrino}_PU200; do
+             ./scripts/prun.sh runPerformanceNTuple.py  $SAMPLES $X ${X}.${V}  --inline-customize 'addCHS();addTKs()';
+         done
+         ;;
+    plot-jets)
+         #for X in {TTbar,VBF_HToInvisible}_PU200; do
+         X=TTbar_PU200
+            #python scripts/respPlots.py perfTuple_${X}.${V}.root -p jet --no-eta -G $PLOTDIR/${X} -w l1pfpu --ymax 2.2 --ymaxRes 0.9 -E 3.0
+            f104v0=plots/106X/from104X/v0/val/${X}
+            me=$PLOTDIR/${X}
+            PT="pt"; X="jet"; 
+            for W in Puppi; do for G in _gauss; do for R in "" _res; do for E in 00_13 13_17 17_25 25_30; do  
+                    plot=${X}_eta_${E}${R}${G}-l1pfpu_${PT}
+                    python scripts/stackPlotsFromFiles.py --legend="TR" $me/${plot}-comp-${W}.png ${W}${G}${R} MTD_MC=$f104v0/$plot.root,Azure+2 L1T_MC=$me/$plot.root,Green+2;
+            done; done; done; done;
+          X=VBF_HToInvisible_PU200
+            #python scripts/respPlots.py perfTuple_${X}.${V}.root -p jet --no-eta -G $PLOTDIR/${X} -w l1pfpu --ymax 2.5 --ymaxRes 0.9 --eta 3.0 5.0 --ptmax 150
+            #python scripts/respPlots.py perfTuple_${X}.${V}.root -p jet --no-eta -G $PLOTDIR/${X} -w l1pfpu --ymax 2.5 --ymaxRes 0.9 --eta 3.5 4.5 --ptmax 150
+            f104v0=plots/106X/from104X/v0/val/${X}
+            me=$PLOTDIR/${X}
+            PT="pt"; X="jet"; 
+            for W in Puppi; do for G in _gauss; do for R in "" _res; do for E in 35_45 30_50; do  
+                    plot=${X}_eta_${E}${R}${G}-l1pfpu_${PT}
+                    python scripts/stackPlotsFromFiles.py --legend="TR" $me/${plot}-comp-${W}.png ${W}${G}${R} MTD_MC=$f104v0/$plot.root,Azure+2 L1T_MC=$me/$plot.root,Green+2;
+            done; done; done; done;
+            #done
+         ;;
+    run-rates)
+         python runPerformanceNTuple.py || exit 1;
+         for X in {SingleNeutrino,VBF_HToInvisible}_PU200; do
+             ./scripts/prun.sh runPerformanceNTuple.py  $SAMPLES $X ${X}.${V}  --inline-customize 'addCHS();addTKs()';
+         done
+         ;;
+    jecs)
+         X=TTbar_PU200; Y=VBF_HToInvisible_PU200;
+         python scripts/makeJecs.py perfNano_${X}.${V}.root perfNano_${Y}.${V}.root  -A  -o jecs.${V}.root 
+         ;;
+    plot-rates)
+         X=TTbar_PU200; Y=VBF_HToInvisible_PU200;
+         #python scripts/makeJecs.py perfNano_${X}.${V}.root perfNano_${Y}.${V}.root  -A  -o jecs.${V}.root 
+         for X in {TTbar,VBF_HToInvisible}_PU200; do 
+         #    python scripts/jetHtSuite.py perfNano_${X}.${V}.root perfNano_SingleNeutrino_PU200.${V}.root $PLOTDIR/met/$X -j jecs.${V}.root -w l1pfpu -v met --eta 5.0
+            f104v0=plots/106X/from104X/v0/val/met/${X}
+            me=$PLOTDIR/met/${X}
+            W="Puppi"; 
+            for plot in metisorate-l1pfpu_eta5.0_pt30_{1,2,5}0kHz; do
+                python scripts/stackPlotsFromFiles.py --legend="TR" $me/${plot}-comp-${W}.png ${W}_eff MTD_MC=$f104v0/$plot.root,Azure+2 L1T_MC=$me/$plot.root,Green+2;
+            done
+         done
+         X=TTbar_PU200; 
+         #python scripts/jetHtSuite.py perfNano_${X}.${V}.root perfNano_SingleNeutrino_PU200.${V}.root $PLOTDIR/ht/$X -j jecs.${V}.root -w l1pfpu -v jet1 --eta 2.4
+         #python scripts/jetHtSuite.py perfNano_${X}.${V}.root perfNano_SingleNeutrino_PU200.${V}.root $PLOTDIR/ht/$X -j jecs.${V}.root -w l1pfpu -v jet4 --eta 2.4
+         #python scripts/jetHtSuite.py perfNano_${X}.${V}.root perfNano_SingleNeutrino_PU200.${V}.root $PLOTDIR/ht/$X -j jecs.${V}.root -w l1pfpu -v ht   --eta 2.4
+         #python scripts/jetHtSuite.py perfNano_${X}.${V}.root perfNano_SingleNeutrino_PU200.${V}.root $PLOTDIR/ht/$X -j jecs.${V}.root -w l1pfpu -v ht   --eta 3.5
+            f104v0=plots/106X/from104X/v0/val/ht/${X}
+            me=$PLOTDIR/ht/${X}
+            W="Puppi"; 
+            for plot in jet{1,4}isorate-l1pfpu_eta2.4_pt10_20kHz htisorate-l1pfpu_eta{2.4,3.5}_pt30_20kHz; do
+                python scripts/stackPlotsFromFiles.py --legend="TR" $me/${plot}-comp-${W}.png ${W}_eff MTD_MC=$f104v0/$plot.root,Azure+2 L1T_MC=$me/$plot.root,Green+2;
+            done
+         X=VBF_HToInvisible_PU200; 
+         #python scripts/jetHtSuite.py perfNano_${X}.${V}.root perfNano_SingleNeutrino_PU200.${V}.root $PLOTDIR/ht/$X -j jecs.${V}.root -w l1pfpu -v jet2       --eta 4.7
+         #python scripts/jetHtSuite.py perfNano_${X}.${V}.root perfNano_SingleNeutrino_PU200.${V}.root $PLOTDIR/ht/$X -j jecs.${V}.root -w l1pfpu -v ptj-mjj620 --eta 4.7
+
+         ;;
+esac;


### PR DESCRIPTION
Updating configuration and documentation to latest L1PF_10_6_1p2_X branch
 * Supported inputs for `scripts/prun.sh` are `--v0` (104X MTD samples) and `--106X_v0` (L1T samples)
 * Added a few scripts to run validation of the various responses and rates
 * Includes #43 from @jmduarte 
