### PR TITLE
Update baseline regions for TDR and multiplicity plotting

### DIFF
--- a/NtupleProducer/python/display/examplePlot.py
+++ b/NtupleProducer/python/display/examplePlot.py
@@ -1,0 +1,35 @@
+import ROOT 
+
+def CreateCanvas(CanvasName = "myPlot", LogY = False, Grid = True):
+  c = ROOT.TCanvas(CanvasName,CanvasName,800,800)
+  c.SetLeftMargin(0.13)
+  if Grid: c.SetGrid()
+  if LogY: c.SetLogy()
+  return c
+
+def DrawPrelimLabel(c):
+  c.cd()
+  tex = ROOT.TLatex()
+  tex.SetTextSize(0.03)
+  tex.DrawLatexNDC(0.13,0.91,"#scale[1.5]{CMS}")
+  tex.Draw("same")
+  
+def DrawLumiLabel(c, Lumi = "35.9"):
+  c.cd()
+  tex = ROOT.TLatex()
+  tex.SetTextSize(0.035)
+  tex.SetTextFont(42)
+  if Lumi!="":
+    toDisplay = Lumi + " fb^{-1} (13 TeV)"
+    tex.DrawLatexNDC(0.66,0.91,toDisplay)
+  else:
+    toDisplay = "(13 TeV)"
+    tex.DrawLatexNDC(0.77,0.91,toDisplay)
+  tex.Draw("same")
+
+def SaveCanvas(c, PlotName = "myPlotName"):
+  c.cd()
+  c.SaveAs(PlotName + ".pdf")
+  c.SaveAs(PlotName + ".png")
+  c.SaveAs(PlotName + ".root")
+

--- a/NtupleProducer/python/runPerformanceNTuple.py
+++ b/NtupleProducer/python/runPerformanceNTuple.py
@@ -170,7 +170,7 @@ for D in ['Barrel','HF','HGCal','HGCalNoTK']:
 def goRegional():
     process.l1pfProducerBarrel.regions = cms.VPSet(
         cms.PSet(
-            etaBoundaries = cms.vdouble(-1.5, -0.75, 0, 0.75, 1.5),
+            etaBoundaries = cms.vdouble(-1.5, -0.5, 0.5, 1.5),
             etaExtra = cms.double(0.25),
             phiExtra = cms.double(0.25),
             phiSlices = cms.uint32(9)
@@ -206,13 +206,13 @@ def goRegional():
     )
     process.l1pfProducerHF.regions = cms.VPSet(
         cms.PSet(
-            etaBoundaries = cms.vdouble(-5, -4.5, -4, -3.5, -3),
+            etaBoundaries = cms.vdouble(-5, -4, -3),
             etaExtra = cms.double(0.25),
             phiExtra = cms.double(0.25),
             phiSlices = cms.uint32(9)
         ),
         cms.PSet(
-            etaBoundaries = cms.vdouble(3, 3.5, 4, 4.5, 5),
+            etaBoundaries = cms.vdouble(3, 4, 5),
             etaExtra = cms.double(0.25),
             phiExtra = cms.double(0.25),
             phiSlices = cms.uint32(9)

--- a/NtupleProducer/python/scripts/objMultiplicityPlot.py
+++ b/NtupleProducer/python/scripts/objMultiplicityPlot.py
@@ -3,79 +3,93 @@ from sys import argv
 import ROOT
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 ROOT.gROOT.SetBatch(True)
-ROOT.gStyle.SetOptStat(False)
+ROOT.gStyle.SetOptStat(0)
+ROOT.gStyle.SetOptTitle(0)
 ROOT.gStyle.SetErrorX(0.5)
 ROOT.gErrorIgnoreLevel = ROOT.kWarning
-
 from math import *
-
 from optparse import OptionParser
+import sys
+sys.path.insert(0,'./')
+from display.examplePlot import *
+
 parser = OptionParser("%(prog) infile [ src [ dst ] ]")
-parser.add_option("--cl", type=float, dest="cl", default=0, help="Compute number to avoid truncations at this CL")
-parser.add_option("-p", type="string", dest="particles", action="append", default=[], help="objects to count")
-parser.add_option("-d", dest="detector", choices=["Barrel","HF","HGCal","HGCalNoTK"], default="Barrel", help="choice of detector: Barrel, HGCal, HGCalNoTK, HF")
+parser.add_option("--cl", type=float, dest="cl", default=0.95, help="Compute number to avoid truncations at this CL")
+parser.add_option("-p", type="string", dest="particles", action="append", default=[], help="objects to count: Calo, EmCalo, Mu, TK, PF, Puppi [PF,Puppi]Charged, [PF,Puppi]Neutral, [PF,Puppi]ChargedHadron, [PF,Puppi]NeutralHadron, [PF,Puppi]Photon, [PF,Puppi]Electron, [PF,Puppi]Muon; default is all")
+parser.add_option("-d", type="string", dest="detectors", action='append', default=[], help="choice of detector: Barrel, HGCal, HGCalNoTK, HF; default is all")
+parser.add_option("-s", dest="sample", choices =['ttbar_200pu','vbf_200pu'], default = 'ttbar_200pu', help="choice of sample: ttbar_200pu and vbf_200pu")
 options, args = parser.parse_args()
-if options.cl == 0:
-    odir = args[1] 
-    os.system("mkdir -p "+odir)
-    os.system("cp %s/src/FastPUPPI/NtupleProducer/python/display/index.php %s/" % (os.environ['CMSSW_BASE'], odir));
-    ROOT.gROOT.ProcessLine(".x %s/src/FastPUPPI/NtupleProducer/python/display/tdrstyle.cc" % os.environ['CMSSW_BASE']);
-elif options.cl >= 1:
+
+odir = args[1] 
+os.system("mkdir -p "+odir)
+#os.system("cp %s/src/FastPUPPI/NtupleProducer/python/display/index.php %s/" % (os.environ['CMSSW_BASE'], odir))
+#ROOT.gROOT.ProcessLine(".x %s/src/FastPUPPI/NtupleProducer/python/display/tdrstyle.cc" % os.environ['CMSSW_BASE'])
+
+if options.cl >= 1:
     raise RuntimeError("--cl must take an argument stricly between 0 and 1")
 
-c1 = ROOT.TCanvas("c1","c1")
+c1 = CreateCanvas("c1",Grid=False)
+
+detectors = ["Barrel","HF","HGCal","HGCalNoTK"]
 particles = [ "Calo", "EmCalo", "Mu", "TK" ]
-detectorLabel = options.detector
-detectorFull = 'l1pfProducer' + options.detector
 for Algo in "PF", "Puppi":
     particles.append(Algo)
     for Type in "Charged Neutral ChargedHadron NeutralHadron Photon Electron Muon".split():
         particles.append(Algo+Type)
+
 tfile = ROOT.TFile.Open(args[0])
 tree = tfile.Get("ntuple/tree")
-ROOT.gStyle.SetOptStat("omr")
-for particle in particles:
-    if options.particles and (particle not in options.particles): continue
-    if options.cl > 0:
-        n = tree.Draw("min(%smaxNL1%s,199)>>htemp(200,-0.5,199.5)" % (detectorFull,particle), "mc_id == 998", "")
-        if not n: continue
-        h = ROOT.gROOT.FindObject("htemp")
-        acc = 0
-        for b in xrange(0,h.GetNbinsX()+2):
-            acc += h.GetBinContent(b)
-            if acc > n * options.cl: 
-                print "%-20s %3.0f" % (particle, h.GetBinCenter(b))
-                break
-    else:
-        for x in "tot","max":
+for detector in detectors:
+    if options.detectors and (detector not in options.detectors): continue
+    detectorLabel = detector
+    detectorFull = 'l1pfProducer' + detectorLabel
+    for particle in particles:
+        if options.particles and (particle not in options.particles): continue
+        if options.cl > 0:
+            n = tree.Draw("min(%smaxNL1%s,199)>>htemp(200,-0.5,199.5)" % (detectorFull,particle), "mc_id == 998", "")
+            if not n: continue
+            h = ROOT.gROOT.FindObject("htemp")
+            acc = 0
+            min_obj = -1
+            for b in xrange(0,h.GetNbinsX()+2):
+                acc += h.GetBinContent(b)
+                if acc > n * options.cl: 
+                    min_obj = h.GetBinCenter(b)
+                    print "%-20s %3.0f" % (particle, min_obj)
+                    break
+        for x in "tot","max","vec":
             print "plotting %s%sNL1%s" % (detectorFull, x, particle)
             n = tree.Draw("%s%sNL1%s" % (detectorFull, x, particle), "mc_id == 998", "")
+            if not n: continue
             h = ROOT.gROOT.FindObject("htemp")
             if x=='tot':
+                h.GetYaxis().SetTitle("Events")
                 h.GetXaxis().SetTitle("Total %s in %s"%(particle, detectorLabel))
+            elif x=='vec':
+                h.GetYaxis().SetTitle('Regions')
+                h.GetXaxis().SetTitle("%s in %s region"%(particle, detectorLabel))
             else:
+                h.GetYaxis().SetTitle("Events")
                 h.GetXaxis().SetTitle("Max %s per %s region"%(particle, detectorLabel))
-            h.GetYaxis().SetTitle("Events")
             h.Draw()
-            if not n: continue
-            for ext in "pdf","png":
-                out = odir+'/'+particle+"_"+detectorLabel+"_"+x+"."+ext
-                c1.Print(out)
-            tfout = ROOT.TFile.Open(odir+'/'+particle+"_"+detectorLabel+"_"+x+".root", "RECREATE");
-            tfout.WriteTObject(h);
-            tfout.Close()
-        print "plotting %svecNL1%s" % (detectorFull, particle)
-        n = tree.Draw("%svecNL1%s" % (detectorFull, particle), "mc_id == 998", "")
-        h = ROOT.gROOT.FindObject("htemp")
-        h.GetXaxis().SetTitle("%s in %s region"%(particle, detectorLabel))
-        h.GetYaxis().SetTitle("Regions")
-        h.Draw()
-        c1.SetLogy()
-        if not n: continue
-        for ext in "pdf","png":
-            out = odir+'/'+particle+"_"+detectorLabel+"_vec."+ext
-            c1.Print(out)
-        tfout = ROOT.TFile.Open(odir+'/'+particle+"_"+detectorLabel+"_vec.root", "RECREATE");
-        tfout.WriteTObject(h);
-        tfout.Close()
+            if x=='vec': 
+                c1.SetLogy(1)
+            else:
+                c1.SetLogy(0)
+            if x=='max' and options.cl>0:
+                h.SetMaximum(1.4*h.GetMaximum())
+                leg = ROOT.TLegend(0.20,0.76,0.75,0.86)
+                leg.SetBorderSize(0)
+                leg.SetFillStyle(0)
+                leg.SetTextSize(0.03)
+                if options.sample=='ttbar_200pu':
+                    leg.SetHeader("t#bar{t}, 200 PU")
+                else:
+                    leg.SetHeader("VBF, 200 PU")
+                leg.AddEntry(h, "Min. objects (%.0f%% no trunc.): %i"%(options.cl*100., min_obj))
+                leg.Draw("same")
+            DrawPrelimLabel(c1)
+            DrawLumiLabel(c1, Lumi="")
+            out = odir+'/'+particle+"_"+detectorLabel+"_"+x
+            SaveCanvas(c1,PlotName=out)
             


### PR DESCRIPTION
This PR:
 * 916539f: Updates the baseline number of regions to 27 in the barrel and 36 in the HF (assumed to be ok, but PUPPI resources still need to be checked)
 * 5e41782: Updates / cleans up plotting script to give output like using a python version of [PlotTemplate.C](https://github.com/davignon/PlottingTemplate/blob/master/PlotTemplate.C):
![Calo_Barrel_max](https://user-images.githubusercontent.com/4932543/65894927-71abe600-e35f-11e9-9060-7b9a44e9c507.png)
