### PR TITLE
Improve 106X performance & plotting scripts

### DIFF
--- a/NtupleProducer/python/plotTemplate.py
+++ b/NtupleProducer/python/plotTemplate.py
@@ -29,12 +29,18 @@ class plotTemplate:
         tex.DrawLatexNDC(0.96,0.95,"%s%s, %s PU" % (energy, ", 3000 fb^{-1}" if lumi else "", pu))
     def SetLogy(self, logy):
         self.canvas.SetLogy(logy)
-    def Print(self,basename, exts=["png","pdf"]):
+    def Print(self,basename, exts=["png","pdf","eps"]):
         errorLevel = ROOT.gErrorIgnoreLevel
         ROOT.gErrorIgnoreLevel = ROOT.kWarning
         if self.outdir: basename = self.outdir + "/" + basename
         for e in exts:
+            if (e == "png") and "eps" in exts: continue
             self.canvas.Print(basename+"."+e)
+        if "png" in exts and "eps" in exts:
+            ret = os.system("LD_LIBRARY_PATH=\"/lib64:$LD_LIBRARY_PATH\" convert -density 150 -quality 100 %s.eps %s.png" % (basename,basename))
+            if ret != 0 and not os.path.exists(basename+".png"):
+                # fall back to plain root, even if it doesn't work great
+                self.canvas.Print(basename+".png")
         ROOT.gErrorIgnoreLevel = errorLevel
 
 

--- a/NtupleProducer/python/plotTemplate.py
+++ b/NtupleProducer/python/plotTemplate.py
@@ -27,6 +27,11 @@ class plotTemplate:
         tex.SetTextSize(0.035)
         tex.SetTextAlign(31)
         tex.DrawLatexNDC(0.96,0.95,"%s%s, %s PU" % (energy, ", 3000 fb^{-1}" if lumi else "", pu))
+    def addSpam(self,x1,y1,text,textSize=0.035,textAlign=21):
+        tex = ROOT.TLatex()
+        tex.SetTextSize(textSize)
+        tex.SetTextFont(42)
+        tex.DrawLatexNDC(x1,y1,text)
     def SetLogy(self, logy):
         self.canvas.SetLogy(logy)
     def Print(self,basename, exts=["png","pdf","eps"]):

--- a/NtupleProducer/python/runPerformanceNTuple.py
+++ b/NtupleProducer/python/runPerformanceNTuple.py
@@ -13,7 +13,7 @@ process.MessageLogger.cerr.FwkReport.reportEvery = 1
 
 process.source = cms.Source("PoolSource",
                             fileNames = cms.untracked.vstring(
-                                'file:/eos/cms/store/cmst3/user/gpetrucc/l1tr/105X/NewInputs104X/010319/TTbar_PU200/inputs104X_TTbar_PU200_job1.root',
+                                'file:/eos/cms/store/cmst3/group/l1tr/gpetrucc/106X/NewInputs104X/240719_oldhgc.done/TTbar_PU200/inputs104X_1.root',
                             ),
     duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
     skipBadFiles = cms.untracked.bool(True),
@@ -136,6 +136,9 @@ process.l1pfjetTable = cms.EDProducer("L1PFJetTableProducer",
     ),
 )
 
+process.l1pfjetTable.jets.RefTwoLayerJets = cms.InputTag("TwoLayerJets", "L1TwoLayerJets")
+process.l1pfjetTable.jets.RefTwoLayerJets_sel = cms.string("pt > 5")
+
 process.l1pfmetTable = cms.EDProducer("L1PFMetTableProducer",
     genMet = cms.InputTag("genMetTrue"), 
     flavour = cms.string(""),
@@ -144,6 +147,9 @@ process.l1pfmetTable = cms.EDProducer("L1PFMetTableProducer",
 )
 process.l1pfmetCentralTable = process.l1pfmetTable.clone(genMet = "genMetCentralTrue", flavour = "Central")
 process.l1pfmetBarrelTable  = process.l1pfmetTable.clone(genMet = "genMetBarrelTrue", flavour = "Barrel")
+
+process.l1pfmetTable.mets.RefL1TrackerEtMiss = cms.InputTag("L1TrackerEtMiss","trkMET")
+process.l1pfmetCentralTable.mets.RefL1TrackerEtMiss = cms.InputTag("L1TrackerEtMiss","trkMET")
 
 monitorPerf("L1Calo", "l1pfCandidates:Calo", makeRespSplit = False)
 monitorPerf("L1TK", "l1pfCandidates:TK", makeRespSplit = False, makeJets=False, makeMET=False)

--- a/NtupleProducer/python/runPerformanceNTuple.py
+++ b/NtupleProducer/python/runPerformanceNTuple.py
@@ -395,3 +395,9 @@ def goGun(calib=1):
 def goMT(nthreads=2):
     process.options.numberOfThreads = cms.untracked.uint32(nthreads)
     process.options.numberOfStreams = cms.untracked.uint32(0)
+def noPU():
+    for X in "", "EM", "Raw", "EMRaw":
+        pfc = getattr(process, 'pfClustersFromHGC3DClusters'+X, None)
+        if not pfc: continue
+        pfc.emVsPUID.wp = "-1.0"
+

--- a/NtupleProducer/python/runRespNTupler.py
+++ b/NtupleProducer/python/runRespNTupler.py
@@ -191,6 +191,10 @@ def hgcAcc(pdgId,pt=10,eta=(1.6,2.6),prompt=False):
     )
     process.p.insert(0, process.acceptance)
 
+def noPU():
+    for X in "", "EM", "Raw", "EMRaw":
+        pfc = getattr(process, 'pfClustersFromHGC3DClusters'+X)
+        pfc.emVsPUID.wp = "-1.0"
 def goOld():
     process.pfClustersFromL1EGClusters.corrector  = "L1Trigger/Phase2L1ParticleFlow/data/emcorr_barrel_93X.root"
     process.pfClustersFromHGC3DClustersEM.corrector =  "L1Trigger/Phase2L1ParticleFlow/data/emcorr_hgc_old3d_93X.root"

--- a/NtupleProducer/python/scripts/doRespCorrs.sh
+++ b/NtupleProducer/python/scripts/doRespCorrs.sh
@@ -81,7 +81,7 @@ case $W in
          python runRespNTupler.py || exit 1;
          for f in $NTUPLES; do test -f $f && mv -v $f ${f/$V/$V.0}; done
          for X in Particle{Gun,GunPt0p5To5,GunPt80To300}_${PU}; do 
-             ./scripts/prun.sh runRespNTupler.py $SAMPLES $X ${X}.${V}  --inline-customize 'goGun()'; 
+             ./scripts/prun.sh runRespNTupler.py $SAMPLES $X ${X}.${V}  --inline-customize 'goGun();noPU()'; 
              grep -q '^JOBS:.*, 0 passed' respTupleNew_${X}.${V}.report.txt && echo " === ERROR. Will stop here === " && break || true;
          done
          ;;

--- a/NtupleProducer/python/scripts/doRespCorrs.sh
+++ b/NtupleProducer/python/scripts/doRespCorrs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-V="v0"
+V="v0.1"
 PLOTDIR="plots/106X/from104X/${V}/corr"
 SAMPLES="--v0";
 

--- a/NtupleProducer/python/scripts/valSuite.sh
+++ b/NtupleProducer/python/scripts/valSuite.sh
@@ -3,7 +3,7 @@
 V="$1"; shift
 PLOTDIR="plots/106X/from104X/${V}/val"
 SAMPLES="--$V";
-[[ "$V" == "v0.1" ]] && SAMPLES="--v0"
+[[ "$V" == "v0.1" || "$V" == "v0.2" ]] && SAMPLES="--v0"
 [[ "$V" == "v3" ]] && SAMPLES="--v3_fat"
 
 W=$1; shift;
@@ -58,7 +58,7 @@ while [[ "$W" != "" ]]; do
     run-jets-nopu)
          python runPerformanceNTuple.py || exit 1;
          for X in TTbar_PU0; do
-             ./scripts/prun.sh runPerformanceNTuple.py  $SAMPLES $X ${X}.${V}  --inline-customize 'addCHS();addTKs()'; 
+             ./scripts/prun.sh runPerformanceNTuple.py  $SAMPLES $X ${X}.${V}  --inline-customize 'addCHS();addTKs();noPU()'; 
          done
          ;;
     plot-jets-nopu)
@@ -114,9 +114,11 @@ while [[ "$W" != "" ]]; do
              ./scripts/prun.sh runPerformanceNTuple.py  $SAMPLES $X ${X}.${V}  --inline-customize 'addCHS();addTKs()' --maxfiles 80;
          done
          ;;
-    plot-rates)
+    make-jecs)
          X=TTbar_PU200; Y=VBF_HToInvisible_PU200;
          python scripts/makeJecs.py perfNano_${X}.${V}.root perfNano_${Y}.${V}.root  -A  -o jecs.${V}.root 
+         ;;
+    plot-rates)
          for X in {TTbar,VBF_HToInvisible}_PU200; do 
              python scripts/jetHtSuite.py perfNano_${X}.${V}.root perfNano_SingleNeutrino_PU200.${V}.root $PLOTDIR/met/$X -j jecs.${V}.root -w l1pfpu -v met --eta 5.0
          done
@@ -125,6 +127,7 @@ while [[ "$W" != "" ]]; do
          python scripts/jetHtSuite.py perfNano_${X}.${V}.root perfNano_SingleNeutrino_PU200.${V}.root $PLOTDIR/ht/$X -j jecs.${V}.root -w l1pfpu -v jet4 --eta 2.4
          python scripts/jetHtSuite.py perfNano_${X}.${V}.root perfNano_SingleNeutrino_PU200.${V}.root $PLOTDIR/ht/$X -j jecs.${V}.root -w l1pfpu -v ht   --eta 2.4
          python scripts/jetHtSuite.py perfNano_${X}.${V}.root perfNano_SingleNeutrino_PU200.${V}.root $PLOTDIR/ht/$X -j jecs.${V}.root -w l1pfpu -v ht   --eta 3.5
+         python scripts/jetHtSuite.py perfNano_${X}.${V}.root perfNano_SingleNeutrino_PU200.${V}.root $PLOTDIR/ht/$X -j jecs.${V}.root -w l1pfpu -v jet4 --eta 3.5
          X=VBF_HToInvisible_PU200; 
          python scripts/jetHtSuite.py perfNano_${X}.${V}.root perfNano_SingleNeutrino_PU200.${V}.root $PLOTDIR/ht/$X -j jecs.${V}.root -w l1pfpu -v jet2       --eta 4.7
          python scripts/jetHtSuite.py perfNano_${X}.${V}.root perfNano_SingleNeutrino_PU200.${V}.root $PLOTDIR/ht/$X -j jecs.${V}.root -w l1pfpu -v ptj-mjj620 --eta 4.7
@@ -138,7 +141,7 @@ while [[ "$W" != "" ]]; do
          done
          X=TTbar_PU200; 
          v0=plots/106X/from104X/v0/val/ht/${X}; me=$PLOTDIR/ht/${X}; W="Puppi"; 
-         for plot in jet{1,4}isorate-l1pfpu_eta2.4_pt10_20kHz htisorate-l1pfpu_eta{2.4,3.5}_pt30_20kHz; do
+         for plot in jet{1,4}isorate-l1pfpu_eta2.4_pt10_20kHz jet4isorate-l1pfpu_eta3.5_pt10_20kHz htisorate-l1pfpu_eta{2.4,3.5}_pt30_20kHz; do
              python scripts/stackPlotsFromFiles.py --legend="TR" $me/${plot}-comp-${W}.png ${W}_eff  v0=$v0/$plot.root,Azure+2 ${V}=$me/$plot.root,Green+2;
          done
          X=VBF_HToInvisible_PU200; 


### PR DESCRIPTION
 * when making performance plots, switch off the HGcal "vs PU" BDT
 * for jet & met performance plots, add a set with the reference tracker MET and tracker jets
 * two more set of plots for jetHtSuite: 
    * `plateff`: compare rates & turn-ons for different triggers not at fixed rate but rather with the requirement of reaching a target efficiency (e.g. 90% or 95%) at some gen-level value
   * `platroc`: make a ROC of trigger rate vs gen-level value at which the trigger reaches a given efficiency (e.g. 90% or 95%)