### PR TITLE
Update to CMSSW 11_1_6

### DIFF
--- a/NtupleProducer/README.md
+++ b/NtupleProducer/README.md
@@ -15,7 +15,7 @@ scram b -j8
 The first step is to produce the inputs:
 ```
 cd FastPUPPI/NtupleProducer/python/
-cmsRun runInputs106X.py # 
+cmsRun runInputs110X.py 
 ```
 Currently only these kind of samples are supported:
  * `11_0_X` : HLT TDR, Phase2C9, Geometry D49, HGCal v11.

--- a/NtupleProducer/README.md
+++ b/NtupleProducer/README.md
@@ -1,10 +1,10 @@
 Basic Instructions
 
 ```
-cmsrel CMSSW_11_1_2
-cd CMSSW_11_1_2/src
+cmsrel CMSSW_11_1_6
+cd CMSSW_11_1_6/src
 cmsenv
-git cms-checkout-topic p2l1pfp:L1PF_11_1_2_X
+git cms-checkout-topic p2l1pfp:L1PF_11_1_6_X
 
 # scripts
 git clone git@github.com:p2l1pfp/FastPUPPI.git -b 11_1_X

--- a/NtupleProducer/python/runInputs110X.py
+++ b/NtupleProducer/python/runInputs110X.py
@@ -29,7 +29,7 @@ process.p = cms.Path(
     process.TrackTriggerClustersStubs +
     process.offlineBeamSpot +
     process.TTTracksFromTrackletEmulation +
-    process.TTTracksFromExtendedTrackletEmulation +
+    #process.TTTracksFromExtendedTrackletEmulation +
     process.SimL1Emulator
 )
 
@@ -42,7 +42,7 @@ process.out = cms.OutputModule("PoolOutputModule",
             "keep *_genMetTrue_*_*",
             # --- PF IN
             "keep *_TTTracksFromTrackletEmulation_*_*",
-            "keep *_TTTracksFromExtendedTrackletEmulation_*_*",
+            #"keep *_TTTracksFromExtendedTrackletEmulation_*_*",
             # new ecal and hcal
             "keep *_L1EGammaClusterEmuProducer_*_*",
             # hcal (old, used for HF)

--- a/NtupleProducer/python/runInputs110X.py
+++ b/NtupleProducer/python/runInputs110X.py
@@ -10,7 +10,7 @@ process.load('SimGeneral.MixingModule.mixNoPU_cfi')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T15', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '111X_mcRun4_realistic_Candidate_2020_12_09_15_46_46', '')
 
 process.load('SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff')
 process.load('CalibCalorimetry.CaloTPG.CaloTPGTranscoder_cfi')
@@ -20,7 +20,7 @@ process.load("L1Trigger.TrackFindingTracklet.Tracklet_cfi")
 process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
 
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('/store/relval/CMSSW_11_0_0/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v2/10000/5FCE3C90-998F-F246-AD88-23C0F54CAA21.root'),
+    fileNames = cms.untracked.vstring('/store/mc/Phase2HLTTDRWinter20DIGI/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW/PU200_110X_mcRun4_realistic_v3-v2/110000/005E74D6-B50E-674E-89E6-EAA9A617B476.root',)
 )
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(25))
 process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
@@ -29,6 +29,7 @@ process.p = cms.Path(
     process.TrackTriggerClustersStubs +
     process.offlineBeamSpot +
     process.TTTracksFromTrackletEmulation +
+    process.TTTracksFromExtendedTrackletEmulation +
     process.SimL1Emulator
 )
 
@@ -41,6 +42,7 @@ process.out = cms.OutputModule("PoolOutputModule",
             "keep *_genMetTrue_*_*",
             # --- PF IN
             "keep *_TTTracksFromTrackletEmulation_*_*",
+            "keep *_TTTracksFromExtendedTrackletEmulation_*_*",
             # new ecal and hcal
             "keep *_L1EGammaClusterEmuProducer_*_*",
             # hcal (old, used for HF)

--- a/NtupleProducer/python/runPerformanceNTuple.py
+++ b/NtupleProducer/python/runPerformanceNTuple.py
@@ -30,7 +30,7 @@ from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
 from RecoMET.METProducers.pfMet_cfi import pfMet
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T15', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '111X_mcRun4_realistic_Candidate_2020_12_09_15_46_46', '')
 
 process.load("L1Trigger.Phase2L1ParticleFlow.l1ParticleFlow_cff")
 

--- a/NtupleProducer/python/runPerformanceNTuple.py
+++ b/NtupleProducer/python/runPerformanceNTuple.py
@@ -639,4 +639,11 @@ def doDumpFile(basename="TTbar_PU200"):
         l1pf.genOrigin = cms.InputTag("genParticles","xyz0")
     process.maxEvents.input = 100
 
+def addEDMOutput():
+    process.out = cms.OutputModule("PoolOutputModule",
+                                   fileName = cms.untracked.string("debugPF.root"),
+                                   SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring("p"))
+                               )
+    process.end = cms.EndPath(process.out)
+    process.maxEvents.input = 10
 

--- a/NtupleProducer/python/runRespNTupler.py
+++ b/NtupleProducer/python/runRespNTupler.py
@@ -25,7 +25,7 @@ process.load('SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff') # needed to 
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T15', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '111X_mcRun4_realistic_Candidate_2020_12_09_15_46_46', '')
 
 process.load("L1Trigger.Phase2L1ParticleFlow.l1ParticleFlow_cff")
 process.load("L1Trigger.Phase2L1ParticleFlow.pfClustersFromHGC3DClustersEM_cfi")

--- a/NtupleProducer/python/scripts/doRespCorrs110X.sh
+++ b/NtupleProducer/python/scripts/doRespCorrs110X.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-V="110X_v1.2"
+V="110X_v2.0"
 PLOTDIR="plots/11_1_X/from110X/${V}/corr"
-SAMPLES="--110X_v1";
+SAMPLES="--110X_v2";
 
 PU=PU0
 if [[ "$1" == "--pu200" ]]; then 
@@ -17,7 +17,7 @@ fi
 
 
 
-if [[ "$1" == "--backup" ]]; then  # DoubleMuon_gun_FlatPt-1To100,SingleElectron_PT2to200,SingleKaon_PT0to200_eta1p4To3p1,SinglePhoton_PT2to200
+if [[ "$1" == "--backup" ]]; then # ,DoublePhoton_FlatPt-1To100
     NTUPLES=$(ls ${TUPLE}_{DoubleElectron_FlatPt-1To100,DoublePhoton_FlatPt-1To100,MultiPion_PT0to200,K0Long_PT0to200_gun}_${PU}.${V}.0.root); 
     shift;
 else
@@ -74,7 +74,7 @@ case $W in
     rerun)
          python runRespNTupler.py || exit 1;
          for f in $NTUPLES; do test -f $f && mv -v $f ${f/$V/$V.0}; done
-         for X in {MultiPion_PT0to200,DoublePhoton_FlatPt-1To100,DoubleElectron_FlatPt-1To100,K0Long_PT0to200_gun}_${PU}; do
+         for X in {MultiPion_PT0to200,DoublePhoton_FlatPt-1To100,DoublePhoton_FlatPt-1To100,DoubleElectron_FlatPt-1To100,K0Long_PT0to200_gun}_${PU}; do
              ./scripts/prun.sh runRespNTupler.py $SAMPLES $X ${X}.${V}  --inline-customize 'goGun();noPU();' ;  # --maxfiles 999;
              grep -q '^JOBS:.*, 0 passed' respTupleNew_${X}.${V}.report.txt && echo " === ERROR. Will stop here === " && break || true;
          done

--- a/NtupleProducer/python/scripts/jetHtSuite.py
+++ b/NtupleProducer/python/scripts/jetHtSuite.py
@@ -80,7 +80,7 @@ def makeCumulativeHTEffGenCut(name, corrArray, genArray, genThr, xmax, norm):
     for ib in xrange(0, nbins):
         msum += ret.GetBinContent(nbins-ib) * tot
         ret.SetBinContent(nbins-ib, msum)
-    ret.SetDirectory(None)
+    ret.SetDirectory(ROOT.nullptr)
     return ret
 
 def makeEffHist(name, refArr, corrArr, corrThr, xmax, logxbins=None):

--- a/NtupleProducer/python/scripts/jetHtSuite.py
+++ b/NtupleProducer/python/scripts/jetHtSuite.py
@@ -5,8 +5,7 @@ ROOT.gROOT.SetBatch(True)
 ROOT.gErrorIgnoreLevel = ROOT.kWarning
 
 from array import array
-from math import pow, sin, cos, hypot, sqrt
-import itertools
+from math import pow, sqrt
 from FastPUPPI.NtupleProducer.scripts.makeJecs import _progress
 from FastPUPPI.NtupleProducer.plotTemplate import plotTemplate
 
@@ -26,7 +25,7 @@ def makeCalcCpp(what):
     return None
 
 def makeGenArray(tree, what, ptCut, etaCut):
-    return makeCorrArray(tree, what, "Gen", ptCut, etaCut, None)
+    return makeCorrArray(tree, what, "Gen", ptCut, etaCut, ROOT.nullptr)
 
 def makeCorrArray(tree, what, obj, ptCorrCut, etaCut, corr, _cache={}):
     _key = (id(tree),what,obj,int(ptCorrCut*100),int(etaCut*1000))
@@ -346,16 +345,16 @@ def makePlatRocPlot(signal, background, what, obj, ptcut, jecs, plotparam, _cach
           if plot.GetEfficiency(i) > plotparam:
               graph = plot.CreateGraph()
               xmin, xmax = xaxis.GetBinLowEdge(i-1), xaxis.GetBinCenter(i)
-              if graph.Eval(xmin,None,"S") > plotparam: 
+              if graph.Eval(xmin,ROOT.nullptr,"S") > plotparam: 
                   #print "ERROR xmin for %s @ %g (%g): i = %d" % (what+obj, rate, cut, i)
                   pass
-              elif graph.Eval(xmax,None,"S") < plotparam:
+              elif graph.Eval(xmax,ROOT.nullptr,"S") < plotparam:
                   #print "ERROR xmax for %s @ %g (%g): i = %d" % (what+obj, rate, cut, i)
                   pass
               else:
                   xmid = 0.5*(xmax+xmin)
                   while abs(xmax-xmin) > 0.05*(abs(xmax)+abs(xmin)):
-                      if graph.Eval(xmid,None,"S") < plotparam:
+                      if graph.Eval(xmid,ROOT.nullptr,"S") < plotparam:
                           xmin = xmid
                       else:
                           xmax = xmid

--- a/NtupleProducer/python/scripts/makeJecs.py
+++ b/NtupleProducer/python/scripts/makeJecs.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
 
     etas = map(float,options.etabins.split(","))
     indextemplate = ROOT.TH1F("indextemplate", "", len(etas)-1, array('f', etas))
-    indextemplate.SetDirectory(None)
+    indextemplate.SetDirectory(ROOT.nullptr)
 
     methods = options.methods.split(",")
     ptCorrs = {}

--- a/NtupleProducer/python/scripts/pfjetstudy.py
+++ b/NtupleProducer/python/scripts/pfjetstudy.py
@@ -172,8 +172,9 @@ for iev,event in enumerate(events):
             else:
                 matches = [ p for p in objs if abs(p.eta()) < options.maxEta ]
                 for d in matches: d.dr = 0
+                matches.sort(key = lambda p : p.phi())
+                matches.sort(key = lambda p : p.eta())
                 matches.sort(key = lambda p : -p.pt())
-
             ptsum = 0
             # OK, try some MC matching for them
             if "PF" in a or "Puppi" in a: 

--- a/NtupleProducer/python/scripts/prun.sh
+++ b/NtupleProducer/python/scripts/prun.sh
@@ -9,24 +9,19 @@ fi
 N=8
 if [[ "$1" == "-j" ]]; then N=$2; shift; shift; fi;
 
-#if [[ "$1" == "--106X_v0" ]]; then
-#    shift;
-#    MAIN=/eos/cms/store/cmst3/group/l1tr/gpetrucc/11_1_X/NewInputs106X/200420.done/$1
-#    PREFIX="inputs106X_"
-#    if echo $CODE | grep -q 106X; then
-#        echo "Assume $CODE is ready for 106X";
-#    else
-#        echo "Convert ${CODE}.py to ${CODE/_110X/}_106X.py automatically updating era and geometry";
-#        sed -e 's+Phase2C9+Phase2C8+g' -e 's+GeometryExtended2026D49+GeometryExtended2026D41+' -e 's+auto:phase2_realistic_T15+auto:phase2_realistic+' ${CODE}.py > ${CODE/_110X/}_106X.py;
-#        CODE=${CODE/_110X/}_106X
-#    fi
-if [[ "$1" == "--110X_v1" ]]; then
+
+if [[ "$1" == "--110X_v2" ]]; then
+    shift;
+    MAIN=/eos/cms/store/cmst3/group/l1tr/gpetrucc/11_1_0/NewInputs110X/110121.done/$1
+    PREFIX="inputs110X_"
+elif [[ "$1" == "--110X_v1" ]]; then
     shift;
     MAIN=/eos/cms/store/cmst3/group/l1tr/gpetrucc/11_1_0/NewInputs110X/150720.done/$1
     PREFIX="inputs110X_"
 else 
     echo "You mush specify the version of the input samples to run on "
-    echo "   --110X_v1 : 110X HLT MC inputs remade in 11_1_0_patch2 "
+    echo "   --110X_v2 : 110X HLT MC inputs remade in 11_1_6 (PLEASE USE THIS) "
+    echo "   --110X_v1 : 110X HLT MC inputs remade in 11_1_0_patch2 (old, better NOT to use)"
 fi;
  
 if [[ "$L1TPF_LOCAL_INPUT_DIR" != "" ]] && test -d $L1TPF_LOCAL_INPUT_DIR; then

--- a/NtupleProducer/python/scripts/stackPlotsFromFiles.py
+++ b/NtupleProducer/python/scripts/stackPlotsFromFiles.py
@@ -39,8 +39,14 @@ tobjs = []
 labels = []
 frame = None
 for i,fname in enumerate(args[2:]):
+    obj_to_get = args[1]
     if "," in fname:
-        (fname,colorname) = fname.split(",")
+        if fname.count(",") == 1:
+            (fname,colorname) = fname.split(",")
+        elif fname.count(",") == 2:
+            (fname,obj_to_get,colorname) = fname.split(",")
+        else:
+            raise RuntimeError("Too many commas in '%s' % fname")
         color = eval("ROOT.k"+colorname)
     else:
         color = colors.pop()
@@ -48,13 +54,16 @@ for i,fname in enumerate(args[2:]):
         (name, fname) = fname.split("=")
     else: 
         name = fname.replace(".root","")
+    if not os.path.isfile(fname):
+        print "File %s does not exist" % fname
+        sys.exit(1)
     tfile = ROOT.TFile.Open(fname)
     if not tfile: 
         print "ERROR opening %s" % tfile
         continue
-    tobj = tfile.Get(args[1])
+    tobj = tfile.Get(obj_to_get)
     if not tobj:
-        print "ERROR fetching %r from %s" % (args[1], tfile)
+        print "ERROR fetching %r from %s" % (obj_to_get, tfile)
         tfile.ls()
         continue
     if not frame:

--- a/NtupleProducer/python/scripts/valSuite.sh
+++ b/NtupleProducer/python/scripts/valSuite.sh
@@ -13,24 +13,29 @@ while [[ "$W" != "" ]]; do
     run-pgun)
          [[ "$V" == "v1" ]] && SAMPLES="--v1_fat"
          python runRespNTupler.py || exit 1;
-         for PU in PU0 PU200; do 
-             for X in Particle{Gun,GunPt0p5To5,GunPt80To300}_${PU}; do 
-                 ./scripts/prun.sh  runRespNTupler.py $SAMPLES $X ${X}.${V}  --inline-customize 'goGun()'; 
-                 grep -q '^JOBS:.*, 0 passed' respTupleNew_${X}.${V}.report.txt && echo " === ERROR. Will stop here === " && exit 2;
-             done
+         PU=PU0 
+         for X in {DoubleElectron_FlatPt-1To100,DoublePhoton_FlatPt-1To100,MultiPion_PT0to200,K0Long_PT0to200_gun}_${PU}; do 
+             ./scripts/prun.sh  runRespNTupler.py $SAMPLES $X ${X}.${V}  --inline-customize 'goGun();noPU()'; 
+             grep -q '^JOBS:.*, 0 passed' respTupleNew_${X}.${V}.report.txt && echo " === ERROR. Will stop here === " && exit 2;
+         done
+         PU=PU200 
+         for X in {DoubleElectron_FlatPt-1To100,DoublePhoton_FlatPt-1To100,SinglePion_PT0to200}_${PU}; do 
+             ./scripts/prun.sh  runRespNTupler.py $SAMPLES $X ${X}.${V}  --inline-customize 'goGun()'; 
+             grep -q '^JOBS:.*, 0 passed' respTupleNew_${X}.${V}.report.txt && echo " === ERROR. Will stop here === " && exit 2;
          done
          ;;
     plot-pgun)
          for PU in PU0 PU200; do
-             NTUPLES=$(ls respTupleNew_Particle{Gun,GunPt0p5To5,GunPt80To300}_${PU}.${V}.root);
              if [[ "$PU" == "PU0" ]]; then
+                 NTUPLES=$(ls respTupleNew_{DoubleElectron_FlatPt-1To100,MultiPion_PT0to200,K0Long_PT0to200_gun}_${PU}.${V}.root);
                  python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p electron,photon,pizero -g  --ymaxRes 0.35 --ptmax 150 -E 3.0
                  python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p pion,klong,pimix       -g  --ymaxRes 1.2  --ptmax 150 -E 3.0
                  python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p pion,pizero,pimix      -g  --eta 3.0 5.0  --ymax 3 --ymaxRes 1.5 --label hf  --no-fit 
              else
+                 NTUPLES=$(ls respTupleNew_{DoubleElectron_FlatPt-1To100,SinglePion_PT0to200}_${PU}.${V}.root);
                  python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p electron,photon,pizero -g  --ymax 2.5 --ymaxRes 0.6 --ptmax 80 -E 3.0
-                 python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p pion,klong,pimix       -g  --ymax 2.5 --ymaxRes 1.5 --ptmax 80 -E 3.0
-                 python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p pion,pizero,pimix      -g  --ymax 3.0 --ymaxRes 1.5 --ptmax 80 --eta 3.0 5.0 --label hf  --no-fit 
+                 python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p pion    -g  --ymax 2.5 --ymaxRes 1.5 --ptmax 80 -E 3.0
+                 python scripts/respPlots.py $NTUPLES $PLOTDIR/ParticleGun_${PU} -w l1pf -p pion    -g  --ymax 3.0 --ymaxRes 1.5 --ptmax 80 --eta 3.0 5.0 --label hf  --no-fit 
              fi;
          done
          ;;
@@ -112,7 +117,8 @@ while [[ "$W" != "" ]]; do
     run-rates)
          python runPerformanceNTuple.py || exit 1;
          for X in {TTbar,VBF_HToInvisible,SingleNeutrino}_PU200; do  
-             ./scripts/prun.sh runPerformanceNTuple.py  $SAMPLES $X ${X}.${V}  --inline-customize 'addCHS();addTKs();addRefs(calo=False,tk=False);addSeededConeJets()' --maxfiles 80;
+         #for X in SingleNeutrino_PU200; do  
+             ./scripts/prun.sh runPerformanceNTuple.py  $SAMPLES $X ${X}.${V}  --inline-customize 'addCHS();addTKs();addRefs(calo=False,tk=False);addSeededConeJets()' ;
          done
          ;;
     make-jecs)
@@ -137,20 +143,26 @@ while [[ "$W" != "" ]]; do
          ;;
     stack-rates)
          for X in {TTbar,VBF_HToInvisible}_PU200; do 
-            v0=plots/106X/from104X/v0/val/met/${X}; me=$PLOTDIR/met/${X}; W="Puppi"; 
+            v0=plots/106X/from104X/v1_TDR4.tkPt3/val/met/${X}; 
+            v1=plots/11_1_X/from110X/110X_v1.2/val/met/${X}; 
+            me=$PLOTDIR/met/${X}; W="Puppi"; 
             for plot in metisorate-l1pfpu_eta5.0_pt30_{1,2,5}0kHz; do
-                python scripts/stackPlotsFromFiles.py --legend="TR" $me/${plot}-comp-${W}.png ${W}_eff v0=$v0/$plot.root,Azure+2 ${V}=$me/$plot.root,Green+2;
+                python scripts/stackPlotsFromFiles.py --legend="TR" $me/${plot}-comp-${W}.png ${W}_eff L1TDR=$v0/${plot/l1pfpu/l1pfpu_tkpt3}.root,Gray+2 1112=$v1/${plot/l1pfpu/l1pfpu_metnoref}.root,Azure+2 Now=$me/${plot/l1pfpu/l1pfpu_metnoref}.root,Green+2;
             done
          done
          X=TTbar_PU200; 
-         v0=plots/106X/from104X/v0/val/ht/${X}; me=$PLOTDIR/ht/${X}; W="Puppi"; 
+         v0=plots/106X/from104X/v1_TDR4.tkPt3/val/ht/${X}; 
+         v1=plots/11_1_X/from110X/110X_v1.2/val/ht/${X}; 
+         me=$PLOTDIR/ht/${X}; W="ak4Puppi"; 
          for plot in jet{1,4}isorate-l1pfpu_eta2.4_pt10_20kHz jet4isorate-l1pfpu_eta3.5_pt10_20kHz htisorate-l1pfpu_eta{2.4,3.5}_pt30_20kHz; do
-             python scripts/stackPlotsFromFiles.py --legend="TR" $me/${plot}-comp-${W}.png ${W}_eff  v0=$v0/$plot.root,Azure+2 ${V}=$me/$plot.root,Green+2;
+             python scripts/stackPlotsFromFiles.py --legend="TR" $me/${plot}-comp-${W}.png ${W}_eff L1TDR=$v0/${plot/l1pfpu/l1pfpu_tkpt3}.root,Gray+2 1112=$v1/${plot/l1pfpu/l1pfpu_jetnoref}.root,Azure+2 Now=$me/${plot/l1pfpu/l1pfpu_jetnoref}.root,Green+2; 
          done
          X=VBF_HToInvisible_PU200; 
-         v0=plots/106X/from104X/v0/val/ht/${X}; me=$PLOTDIR/ht/${X} W="Puppi"; 
-         for plot in jet2isorate-l1pfpu_eta4.7_pt10_{1,2,5}0kHz ptj-mjj620isorate-l1pfpu_eta4.7_pt10_{1,2,5}0kHz; do
-             python scripts/stackPlotsFromFiles.py --legend="TR" $me/${plot}-comp-${W}.png ${W}_eff  v0=$v0/$plot.root,Azure+2 ${V}=$me/$plot.root,Green+2;
+         v0=plots/106X/from104X/v1_TDR4.tkPt3/val/ht/${X}; 
+         v1=plots/11_1_X/from110X/110X_v1.2/val/ht/${X}; 
+         me=$PLOTDIR/ht/${X}; W="ak4Puppi"; 
+         for plot in jet2isorate-l1pfpu_eta4.7_pt10_{1,2,5}0kHz ptj-mjj620isorate-l1pfpu_eta4.7_pt20_{1,2,5}0kHz; do
+             python scripts/stackPlotsFromFiles.py --legend="TR" $me/${plot}-comp-${W}.png ${W}_eff  L1TDR=$v0/${plot/l1pfpu/l1pfpu_tkpt3}.root,Gray+2 1112=$v1/${plot/l1pfpu/l1pfpu_jetnoref}.root,Azure+2 Now=$me/${plot/l1pfpu/l1pfpu_jetnoref}.root,Green+2;
          done
          ;;
     run-mult)
@@ -165,6 +177,25 @@ while [[ "$W" != "" ]]; do
              python scripts/objMultiplicityPlot.py perfTuple_${X}.${V}_regional.root  $PLOTDIR/multiplicities/${X} -s $X 
          done;
          ;;
+    run-mult-suite2)
+         python runPerformanceNTuple.py || exit 1;  
+         for X in SMS_T1tttt_mGluino-2100_mLSP-400_PU300 TTTT_PU200 TTbar_PU200 ; do :
+            for nPhi in 9; do 
+                ./scripts/prun.sh runPerformanceNTuple.py  $SAMPLES $X ${X}.${V}_regional_nPhi${nPhi}_noPUBDT  --inline-customize "respOnly();noPU();goRegional();phiSlices(${nPhi})" --maxfiles 32;
+            done;
+         done
+         ;;
+    plot-mult-suite2)
+         for X in SMS_T1tttt_mGluino-2100_mLSP-400_PU{200,300} TTTT_PU{200,300} TTbar_PU200 ; do 
+            for nPhi in 9 ; do 
+                if [ -f perfTuple_${X}.${V}_regional_nPhi${nPhi}_noPUBDT.root ] ; then
+                    python scripts/objMultiplicityPlot.py perfTuple_${X}.${V}_regional_nPhi${nPhi}_noPUBDT.root  $PLOTDIR/multiplicities_nPh_noPUBDTi/${X} -s $X -l _nPhi${nPhi} -d HGCal,HGCalNoTK -p Calo
+                fi
+                break;
+            done;
+         done;
+         ;;
+
   esac;
   W=$1; shift;
 done


### PR DESCRIPTION
Update following the central branch, necessary to get in some e/gamma fixes (used by https://github.com/p2l1pfp/cmssw/pull/38)
A new version of input files is in ` /eos/cms/store/cmst3/group/l1tr/gpetrucc/11_1_0/NewInputs110X/110121.done` (production done for most of the samples), accessible as `110X_v2` in `prun.sh`