### PR TITLE
Update input creation to v4 1400pre3 L1T recipe

### DIFF
--- a/NtupleProducer/README.md
+++ b/NtupleProducer/README.md
@@ -38,6 +38,7 @@ The supported input campaings are:
  * `11_0_X` from the HLT TDR campaign (Phase2C9, Geometry D49, HGCal v11).
 
 Existing input files available are:
+ * `131X_v3`: input files from processing `13_1_X` Phase2Spring23 samples in `CMSSW_14_0_0_pre3` + `cms-l1t-offline:phase2-l1t-1400pre3_v4`, from `/store/cmst3/group/l1tr/cerminar/14_0_X/fpinputs_131X/v3`
  * `131X_v2`: input files from processing `13_1_X` Phase2Spring23 samples in `CMSSW_14_0_X`, from `/store/cmst3/group/l1tr/cerminar/14_0_X/fpinputs_131X/v2`
  * `125X_v0`:  input files from processing `12_5_X` Phase2Fall22 TDR samples in `CMSSW_12_5_3`, from `/store/cmst3/group/l1tr/gpetrucc/12_5_X/NewInputs125X/150223`
  * `110X_v3`:  input files from processing `11_0_X` HLT TDR samples in `CMSSW_12_3_X`, from `/store/cmst3/group/l1tr/gpetrucc/12_3_X/NewInputs110X/220322`: use with `oldInputs_12_3_X()` in `runPerformanceNTuple.py`

--- a/NtupleProducer/README.md
+++ b/NtupleProducer/README.md
@@ -1,15 +1,23 @@
 Basic Instructions
 
 ```
-cmsrel CMSSW_14_0_0_pre1
-cd CMSSW_14_0_0_pre1/src
+cmsrel CMSSW_14_0_0_pre3
+cd CMSSW_14_0_0_pre3/src
 cmsenv
+git cms-init
 git cms-addpkg DataFormats/L1TParticleFlow
 git cms-addpkg DataFormats/L1TCorrelator
 git cms-addpkg L1Trigger/Phase2L1ParticleFlow
 git cms-addpkg L1Trigger/TrackTrigger
 git cms-addpkg SimTracker/TrackTriggerAssociation
 git cms-addpkg L1Trigger/Phase2L1ParticleFlow
+git cms-checkout-topic -u cms-l1t-offline:phase2-l1t-1400pre3_v4
+
+# externals
+git clone https://github.com/jonamotta/L1Trigger-L1CaloTrigger.git L1Trigger/L1CaloTrigger/data/
+git clone https://github.com/omiguelc/L1Trigger-L1TMuonEndCapPhase2.git  -b AddNNProtobufs L1Trigger/L1TMuonEndCapPhase2/data
+git clone git@github.com:BenjaminRS/L1Trigger-VertexFinder.git L1Trigger/VertexFinder/data/
+
 
 # scripts
 git clone git@github.com:p2l1pfp/FastPUPPI.git -b 14_0_X

--- a/NtupleProducer/README.md
+++ b/NtupleProducer/README.md
@@ -11,13 +11,7 @@ git cms-addpkg L1Trigger/Phase2L1ParticleFlow
 git cms-addpkg L1Trigger/TrackTrigger
 git cms-addpkg SimTracker/TrackTriggerAssociation
 git cms-addpkg L1Trigger/Phase2L1ParticleFlow
-git cms-checkout-topic -u cms-l1t-offline:phase2-l1t-1400pre3_v4
-
-# externals
-git clone https://github.com/jonamotta/L1Trigger-L1CaloTrigger.git L1Trigger/L1CaloTrigger/data/
-git clone https://github.com/omiguelc/L1Trigger-L1TMuonEndCapPhase2.git  -b AddNNProtobufs L1Trigger/L1TMuonEndCapPhase2/data
-git clone git@github.com:BenjaminRS/L1Trigger-VertexFinder.git L1Trigger/VertexFinder/data/
-
+git cms-checkout-topic -u cms-l1t-offline:phase2-l1t-1400pre3_v5
 
 # scripts
 git clone git@github.com:p2l1pfp/FastPUPPI.git -b 14_0_X

--- a/NtupleProducer/python/runInputs131X.py
+++ b/NtupleProducer/python/runInputs131X.py
@@ -10,7 +10,7 @@ process.load('SimGeneral.MixingModule.mixNoPU_cfi')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, '131X_mcRun4_realistic_v5', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '131X_mcRun4_realistic_v9', '')
 
 process.load('SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff')
 process.load('CalibCalorimetry.CaloTPG.CaloTPGTranscoder_cfi')

--- a/NtupleProducer/python/runInputs131X.py
+++ b/NtupleProducer/python/runInputs131X.py
@@ -57,8 +57,6 @@ process.PFInputsTask = cms.Task(
    #process.TTTrackAssociatorFromPixelDigisExtended,
    #process.SimL1EmulatorTask
    #process.l1tTkStubsGmt,
-   process.l1tTkMuonsGmt,
-   process.l1tSAMuonsGmt
 )
 process.p = cms.Path(
         process.l1tLayer1 +
@@ -66,6 +64,7 @@ process.p = cms.Path(
         process.l1tLayer2EG
 )
 process.p.associate(process.PFInputsTask)
+process.p.associate(process.SimL1EmulatorTask)
 
 process.out = cms.OutputModule("PoolOutputModule",
         fileName = cms.untracked.string("inputs131X.root"),
@@ -80,6 +79,7 @@ process.out = cms.OutputModule("PoolOutputModule",
             "keep *_TTTrackAssociatorFromPixelDigis_*_*",
             "keep *_TTTrackAssociatorFromPixelDigisExtended_*_*",
             # --- Calo TPs
+            "keep *_simEcalEBTriggerPrimitiveDigis_*_*",
             "keep *_simHcalTriggerPrimitiveDigis_*_*",
             "keep *_simCaloStage2Layer1Digis_*_*",
             "keep *_simCaloStage2Digis_*_*",
@@ -123,6 +123,8 @@ process.out = cms.OutputModule("PoolOutputModule",
             "keep *_l1tTowerCalibration_*_*",
             "keep *_l1tCaloJet_*_*",
             "keep *_l1tCaloJetHTT_*_*",
+            # "keep *_l1tPhase2L1CaloEGammaEmulator_*_*",
+            # "keep *_l1tPhase2CaloPFClusterEmulator_*_*",
             # --- GTT reconstruction
             "keep *_l1tVertexFinder_*_*",
             "keep *_l1tVertexFinderEmulator_*_*",
@@ -137,8 +139,9 @@ process.out = cms.OutputModule("PoolOutputModule",
             "keep *_l1tTrackerEmuHTMiss_*_*",
             "keep *_l1tTrackerEmuHTMissExtended_*_*",
             # --- GMT reconstruction
-            "keep *_l1tTkStubsGmt_*_*",
-            "keep *_l1tTkMuonsGmt_*_*",
+            "keep *_l1tStubsGmt_*_*",
+            "keep *_l1tKMTFMuonsGmt_*_*",
+            "keep *_l1tFwdMuonsGmt_*_*",
             "keep *_l1tSAMuonsGmt_*_*",
         ),
         compressionAlgorithm = cms.untracked.string('LZMA'),

--- a/NtupleProducer/python/runInputs131X.py
+++ b/NtupleProducer/python/runInputs131X.py
@@ -16,9 +16,9 @@ process.load('SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff')
 process.load('CalibCalorimetry.CaloTPG.CaloTPGTranscoder_cfi')
 process.load('Configuration.StandardSequences.SimL1Emulator_cff')
 process.load('L1Trigger.TrackTrigger.TrackTrigger_cff')
-process.load("L1Trigger.TrackFindingTracklet.L1HybridEmulationTracks_cff") 
-process.load("L1Trigger.TrackTrigger.ProducerSetup_cff") 
-process.load("L1Trigger.TrackerDTC.ProducerED_cff") 
+process.load("L1Trigger.TrackFindingTracklet.L1HybridEmulationTracks_cff")
+process.load("L1Trigger.TrackTrigger.ProducerSetup_cff")
+process.load("L1Trigger.TrackerDTC.ProducerED_cff")
 process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
 process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
 
@@ -38,7 +38,7 @@ process.source = cms.Source("PoolSource",
     ),
 )
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(200))
-process.options = cms.untracked.PSet( 
+process.options = cms.untracked.PSet(
         wantSummary = cms.untracked.bool(True),
         #numberOfThreads = cms.untracked.uint32(4),
         #numberOfStreams = cms.untracked.uint32(4),

--- a/NtupleProducer/python/runPerformanceNTuple.py
+++ b/NtupleProducer/python/runPerformanceNTuple.py
@@ -577,7 +577,7 @@ def addTkEG(doL1=False, doL2=True, postfix=""):
         process.extraPFStuff.add(tkEmTable,tkEleTable)
 
 
-def addDecodedTk(regs=['HGCal']):        
+def addDecodedTk(regs=['HGCal','Barrel']):        
     for reg in regs:
         decTkTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
                         name = cms.string("DecTk"+reg),
@@ -605,11 +605,55 @@ def addDecodedTk(regs=['HGCal']):
         process.extraPFStuff.add(decTkTable)
 
 
+
+def addEGCrystalClusters() -> None:
+    def getCrystalClustersTable(nameSrcDict : dict[str, str]) -> cms.EDProducer:
+        CrystalClustersTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+                                        name = cms.string(nameSrcDict["name"]),
+                                        src=cms.InputTag(nameSrcDict["src"]),
+                                        cut = cms.string(""),
+                                        doc = cms.string(""),
+                                        singleton = cms.bool(False), # the number of entries is variable
+                                        extension = cms.bool(False), # this is the main table
+                                        variables = cms.PSet(
+                                            isolation  = Var("isolation", float,precision=8),
+                                            pt  = Var("pt",  float,precision=8),
+                                            eta  = Var("eta", float,precision=8),
+                                            phi = Var("phi", float,precision=8),
+                                            calibratedPt = Var("calibratedPt", float,precision=8),
+                                            hovere = Var("hovere", float,precision=8),
+                                            puCorrPt = Var("puCorrPt", float,precision=8),
+                                            bremStrength = Var("bremStrength", float,precision=8),
+                                            e2x2 = Var("e2x2", float,precision=8),
+                                            e2x5 = Var("e2x5", float,precision=8),
+                                            e3x5 = Var("e3x5", float,precision=8),
+                                            e5x5 = Var("e5x5", float,precision=8),
+                                            standaloneWP = Var("standaloneWP", int,precision=8),
+                                            electronWP98 = Var("electronWP98", int,precision=8),
+                                            photonWP80 = Var("photonWP80", int,precision=8),
+                                            electronWP90 = Var("electronWP90", int,precision=8),
+                                            looseL1TkMatchWP = Var("looseL1TkMatchWP", int,precision=8),
+                                            stage2effMatch= Var("stage2effMatch", int,precision=8),
+                                        )
+            )
+        return CrystalClustersTable
+    
+    nameSrcDictList=[
+        {"name":"CaloEGammaCrystalClustersRCT", "src":"l1tPhase2L1CaloEGammaEmulator:RCTClusters"},
+        {"name":"CaloEGammaCrystalClustersGCT", "src":"l1tPhase2L1CaloEGammaEmulator:GCTClusters"},
+    ]
+    for nameSrcDict in nameSrcDictList:
+        flatTable = getCrystalClustersTable(nameSrcDict)
+        setattr(process, f"{nameSrcDict['name']}Table", flatTable)
+        process.extraPFStuff.add(flatTable)
+
+
 def addAllLeps():
     addGenLep()
     addStaMu()
     addPFLep([13])
     addTkEG()
+    addEGCrystalClusters()
 
 def goGun(calib=1):
     process.ntuple.isParticleGun = True


### PR DESCRIPTION
This includes:
   * fix for the standalone muons. (The inputs are stored in inputs files)
   * add collections needed to rerun the new Calo emulator chain (objects can not yet be persisted...)
