### PR TITLE
[142X] Updating the SimpleTableProducers

### DIFF
--- a/NtupleProducer/python/runPerformanceNTuple.py
+++ b/NtupleProducer/python/runPerformanceNTuple.py
@@ -318,7 +318,7 @@ def addTkPtCut(ptCut):
 
 
 def addGen(pdgs):
-    genLepTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+    genLepTable = cms.EDProducer("SimpleGenParticleFlatTableProducer",
                 src = cms.InputTag("genParticles"),
                 doc = cms.string("gen leptons"),
                 singleton = cms.bool(False), # the number of entries is variable

--- a/NtupleProducer/python/scouting/runJetStudyNTuple.py
+++ b/NtupleProducer/python/scouting/runJetStudyNTuple.py
@@ -97,7 +97,7 @@ process.puppiExtJetsTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         )
 )
 
-process.genParticleTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+process.genParticleTable = cms.EDProducer("SimpleGenParticleFlatTableProducer",
         name = cms.string("GenParticles"),
         cut  = cms.string("abs(eta) < 5"),
         src = cms.InputTag("genParticlesForMETAllVisible"),
@@ -115,7 +115,7 @@ process.genParticleTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         )
 )
 
-process.genVertexTable = cms.EDProducer("SimpleXYZPointFlatTableProducer",
+process.genVertexTable = cms.EDProducer("SimpleGenParticleFlatTableProducer",
     src = cms.InputTag("genParticles:xyz0"),
     cut = cms.string(""),
     name= cms.string("GenVtx"),
@@ -189,7 +189,7 @@ process.genMu = cms.EDFilter("GenParticleSelector",
     cut = cms.string("abs(pdgId) = 13 && status == 1 && pt > 0.5 && abs(eta) < 2.7"),
 )
 
-process.genMuTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+process.genMuTable = cms.EDProducer("SimpleGenParticleFlatTableProducer",
     src = cms.InputTag("genMu"),
     cut = cms.string(""),
     name = cms.string("GenMu"),
@@ -291,7 +291,7 @@ def isSignal():
             "keep+ 9900001 <= abs(pdgId) <= 9900008",
         )
     )
-    process.genHardParticleTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+    process.genHardParticleTable = cms.EDProducer("SimpleGenParticleFlatTableProducer",
             name = cms.string("GenHard"),
             cut  = cms.string(""),
             src = cms.InputTag("genHard"),

--- a/NtupleProducer/python/scouting/runL1BinaryDumpers_cfg.py
+++ b/NtupleProducer/python/scouting/runL1BinaryDumpers_cfg.py
@@ -105,7 +105,7 @@ process.genMu = cms.EDFilter("GenParticleSelector",
     cut = cms.string("abs(pdgId) = 13 && status == 1 && pt > 0.5 && abs(eta) < 2.7"),
 )
 
-process.genMuTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+process.genMuTable = cms.EDProducer("SimpleGenParticleFlatTableProducer",
     src = cms.InputTag("genMu"),
     cut = cms.string(""),
     name = cms.string("GenMu"),
@@ -175,7 +175,7 @@ process.genPiFromW = cms.EDFilter("GenParticleSelector",
         src = cms.InputTag("genParticles"),
         cut = cms.string("abs(pdgId) = 211 && numberOfMothers > 0 && abs(motherRef.pdgId) = 24"),
 )
-process.genWTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+process.genWTable = cms.EDProducer("SimpleGenParticleFlatTableProducer",
                 src = cms.InputTag("genW"),
                 cut = cms.string(""),
                 name = cms.string("GenW"),
@@ -192,7 +192,7 @@ process.genWTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
                     pdgId  = Var("pdgId", int, doc="PDG id"),
                 )
             )
-process.genPiTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+process.genPiTable = cms.EDProducer("SimpleGenParticleFlatTableProducer",
                 src = cms.InputTag("genPiFromW"),
                 cut = cms.string(""),
                 name = cms.string("GenPi"),
@@ -337,7 +337,7 @@ process.genPho = cms.EDFilter("GenParticleSelector",
 process.genEle = process.genPho.clone(
     cut = "pdgId == 11 && status == 1",
 )
-process.genPhoTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+process.genPhoTable = cms.EDProducer("SimpleGenParticleFlatTableProducer",
     src = cms.InputTag("genPho"),
     cut = cms.string(""),
     name = cms.string("GenPho"),

--- a/NtupleProducer/python/scouting/runMuNTuple_cfg.py
+++ b/NtupleProducer/python/scouting/runMuNTuple_cfg.py
@@ -72,7 +72,7 @@ process.genMu = cms.EDFilter("GenParticleSelector",
     cut = cms.string("abs(pdgId) = 13 && status == 1 && pt > 0.5 && abs(eta) < 2.7"),
 )
 
-process.genMuTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+process.genMuTable = cms.EDProducer("SimpleGenParticleFlatTableProducer",
     src = cms.InputTag("genMu"),
     cut = cms.string(""),
     name = cms.string("GenMu"),

--- a/NtupleProducer/python/scouting/runW3PiNtuples_cfg.py
+++ b/NtupleProducer/python/scouting/runW3PiNtuples_cfg.py
@@ -79,7 +79,7 @@ def goSignal():
             src = cms.InputTag("genParticles"),
             cut = cms.string("abs(pdgId) = 211 && numberOfMothers > 0 && abs(motherRef.pdgId) = 24"),
     )
-    process.genWTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+    process.genWTable = cms.EDProducer("SimpleGenParticleFlatTableProducer",
                     src = cms.InputTag("genW"),
                     cut = cms.string(""),
                     name = cms.string("GenW"),
@@ -96,7 +96,7 @@ def goSignal():
                         pdgId  = Var("pdgId", int, doc="PDG id"),
                     )
                 )
-    process.genPiTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+    process.genPiTable = cms.EDProducer("SimpleGenParticleFlatTableProducer",
                     src = cms.InputTag("genPiFromW"),
                     cut = cms.string(""),
                     name = cms.string("GenPi"),


### PR DESCRIPTION
### PR Description
With the merging of https://github.com/cms-sw/cmssw/pull/44782, the `SimpleFlatTableProducer`s are moved to concrete (explicit) data types.
So running (for example) the `NtupleProducer/python/scouting/runW3PiNtuples_cfg.py` script on a Phase2Spring24 file I get the following error:
```
----- Begin Fatal Exception 22-Oct-2024 18:45:20 CEST-----------------------
An exception of category 'Configuration' occurred while
   [0] Constructing the EventProcessor
   [1] Constructing module: class=SimpleCandidateFlatTableProducer label='genPiTable'
Exception Message:
Expression parser error:no method or data member named "statusFlags" found for type "reco::Candidate"
It has the following methods
 charge
 eta
 mass
 pdgId
 phi
----- End Fatal Exception -------------------------------------------------
...
```
With this PR this particular crash is solved.

-----
[RFC]
For the moment I only updated `SimpleCandidateFlatTableProducer` to `SimpleGenParticleFlatTableProducer` for the cases where the input source is `genParticles`, but, judging from the PR, more might need to be updated. FYI @gpetruc @cerminar 