### PR TITLE
Switch to LazyEvaluation for variables in `reco::Candidate` child classes.

### DIFF
--- a/NtupleProducer/python/runPerformanceNTuple.py
+++ b/NtupleProducer/python/runPerformanceNTuple.py
@@ -318,7 +318,7 @@ def addTkPtCut(ptCut):
 
 
 def addGen(pdgs):
-    genLepTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+    genLepTable = cms.EDProducer("SimpleGenParticleFlatTableProducer",
                 src = cms.InputTag("genParticles"),
                 doc = cms.string("gen leptons"),
                 singleton = cms.bool(False), # the number of entries is variable

--- a/NtupleProducer/python/runPerformanceNTuple.py
+++ b/NtupleProducer/python/runPerformanceNTuple.py
@@ -2,6 +2,10 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
 from PhysicsTools.NanoAOD.common_cff import Var, ExtVar 
 
+def LazyVar(expr, valtype, doc=None, precision=-1):
+    return Var(expr, valtype, doc, precision, lazyEval=True)
+
+
 process = cms.Process("RESP", eras.Phase2C17I13M9)
 
 process.load('Configuration.StandardSequences.Services_cff')
@@ -393,7 +397,7 @@ def addStaMu():
                             phi = Var("phi", float,precision=8),
                             eta  = Var("eta", float,precision=8),
                             charge  = Var("charge", int, doc="charge id"),
-                            quality  = Var("hwQual", int, doc="charge id"),
+                            quality  = LazyVar("hwQual", int, doc="charge id"),
                         )
     )
     process.extraPFStuff.add(process.staMuTable)
@@ -408,52 +412,52 @@ def addHGCalTPs():
                 singleton = cms.bool(False), # the number of entries is variable
                 extension = cms.bool(False), # this is the main table
                 variables = cms.PSet(
-                    pt  = Var("pt",  float,precision=8),
-                    phi = Var("phi", float,precision=8),
-                    eta  = Var("eta", float,precision=8),
-                    nTcs = Var("constituents.size",  int,precision=8),
-                    ptEm = Var("iPt('EM')",  float,precision=8),
-                    hwQual = Var("hwQual",  int,precision=8),
-                    showerlength = Var("showerLength", int),
-                    coreshowerlength = Var("coreShowerLength", int),
-                    firstlayer = Var("firstLayer", int),
-                    maxlayer = Var("maxLayer", int),
-                    seetot = Var("sigmaEtaEtaTot", float),
-                    seemax = Var("sigmaEtaEtaMax", float),
-                    spptot = Var("sigmaPhiPhiTot", float),
-                    sppmax = Var("sigmaPhiPhiMax", float),
-                    szz = Var("sigmaZZ", float),
-                    srrtot = Var("sigmaRRTot", float),
-                    srrmax = Var("sigmaRRMax", float),
-                    srrmean = Var("sigmaRRMean", float),
-                    emaxe = Var("eMax/energy", float),
-                    hoe = Var("hOverE", float),
-                    meanz = Var("abs(zBarycenter)", float),
-                    layer10 = Var("layer10percent", float),
-                    layer50 = Var("layer50percent", float),
-                    layer90 = Var("layer90percent", float),
-                    ntc67 = Var("triggerCells67percent", float),
-                    ntc90 = Var("triggerCells90percent", float),
-                    varRR = Var("varRR", float),
-                    varZZ = Var("varZZ", float),
-                    varEtaEta = Var("varEtaEta", float),
-                    varPhiPhi = Var("varPhiPhi", float),
-                    first1layers = Var("first1layers", float),
-                    first3layers = Var("first3layers", float),
-                    first5layers = Var("first5layers", float),
-                    firstHcal1layers = Var("firstHcal1layers", float),
-                    firstHcal3layers = Var("firstHcal3layers", float),
-                    firstHcal5layers = Var("firstHcal5layers", float),
-                    last1layers = Var("last1layers", float),
-                    last3layers = Var("last3layers", float),
-                    last5layers = Var("last5layers", float),
-                    emax1layers = Var("emax1layers", float),
-                    emax3layers = Var("emax3layers", float),
-                    emax5layers = Var("emax5layers", float),
-                    eot = Var("eot", float),
-                    ebm0 = Var("ebm0", int),
-                    ebm1 = Var("ebm1", int),
-                    hbm = Var("hbm", int),
+                    pt  = LazyVar("pt",  float,precision=8),
+                    phi = LazyVar("phi", float,precision=8),
+                    eta  = LazyVar("eta", float,precision=8),
+                    nTcs = LazyVar("constituents.size",  int,precision=8),
+                    ptEm = LazyVar("iPt('EM')",  float,precision=8),
+                    hwQual = LazyVar("hwQual",  int,precision=8),
+                    showerlength = LazyVar("showerLength", int),
+                    coreshowerlength = LazyVar("coreShowerLength", int),
+                    firstlayer = LazyVar("firstLayer", int),
+                    maxlayer = LazyVar("maxLayer", int),
+                    seetot = LazyVar("sigmaEtaEtaTot", float),
+                    seemax = LazyVar("sigmaEtaEtaMax", float),
+                    spptot = LazyVar("sigmaPhiPhiTot", float),
+                    sppmax = LazyVar("sigmaPhiPhiMax", float),
+                    szz = LazyVar("sigmaZZ", float),
+                    srrtot = LazyVar("sigmaRRTot", float),
+                    srrmax = LazyVar("sigmaRRMax", float),
+                    srrmean = LazyVar("sigmaRRMean", float),
+                    emaxe = LazyVar("eMax/energy", float),
+                    hoe = LazyVar("hOverE", float),
+                    meanz = LazyVar("abs(zBarycenter)", float),
+                    layer10 = LazyVar("layer10percent", float),
+                    layer50 = LazyVar("layer50percent", float),
+                    layer90 = LazyVar("layer90percent", float),
+                    ntc67 = LazyVar("triggerCells67percent", float),
+                    ntc90 = LazyVar("triggerCells90percent", float),
+                    varRR = LazyVar("varRR", float),
+                    varZZ = LazyVar("varZZ", float),
+                    varEtaEta = LazyVar("varEtaEta", float),
+                    varPhiPhi = LazyVar("varPhiPhi", float),
+                    first1layers = LazyVar("first1layers", float),
+                    first3layers = LazyVar("first3layers", float),
+                    first5layers = LazyVar("first5layers", float),
+                    firstHcal1layers = LazyVar("firstHcal1layers", float),
+                    firstHcal3layers = LazyVar("firstHcal3layers", float),
+                    firstHcal5layers = LazyVar("firstHcal5layers", float),
+                    last1layers = LazyVar("last1layers", float),
+                    last3layers = LazyVar("last3layers", float),
+                    last5layers = LazyVar("last5layers", float),
+                    emax1layers = LazyVar("emax1layers", float),
+                    emax3layers = LazyVar("emax3layers", float),
+                    emax5layers = LazyVar("emax5layers", float),
+                    eot = LazyVar("eot", float),
+                    ebm0 = LazyVar("ebm0", int),
+                    ebm1 = LazyVar("ebm1", int),
+                    hbm = LazyVar("hbm", int),
                     )
             )
     from L1Trigger.Phase2L1ParticleFlow.l1tPFClustersFromHGC3DClusters_cfi import l1tPFClustersFromHGC3DClusters
@@ -491,29 +495,29 @@ def addPFLep(pdgs=[11,13,22],opts=["PF","Puppi"], postfix=""):
                             name = cms.string(w+"Mu"+postfix))
                 setattr(process, w+"Mu"+postfix+"Table", muTable)
                 process.extraPFStuff.add(muTable)
-                muTable.variables.quality = Var("? muon.isNonnull ? muon.hwQual : -1", int, doc="Quality")
+                muTable.variables.quality = LazyVar("? muon.isNonnull ? muon.hwQual : -1", int, doc="Quality")
             elif pdgId == 11:
                 elTable = pfLepTable.clone(
                             cut  = cms.string("abs(pdgId) == %d && pt > 2" % pdgId),
                             name = cms.string(w+"El"+postfix))
                 setattr(process, w+"El"+postfix+"Table", elTable)
                 process.extraPFStuff.add(elTable)
-                elTable.variables.hwEmID = Var("? pfCluster.isNonnull ? pfCluster.hwEmID : -1", int, doc="Quality")
-                elTable.variables.pfEmID = Var("? pfCluster.isNonnull ? pfCluster.egVsPionMVAOut : -1", float, precision=8)
-                elTable.variables.pfPuID = Var("? pfCluster.isNonnull ? pfCluster.egVsPUMVAOut : -1", float, precision=8)
-                elTable.variables.clPt   = Var("? pfCluster.isNonnull ? pfCluster.pt : -1", float, precision=8)
-                elTable.variables.clEmEt = Var("? pfCluster.isNonnull ? pfCluster.emEt : -1", float, precision=8)
+                elTable.variables.hwEmID = LazyVar("? pfCluster.isNonnull ? pfCluster.hwEmID : -1", int, doc="Quality")
+                elTable.variables.pfEmID = LazyVar("? pfCluster.isNonnull ? pfCluster.egVsPionMVAOut : -1", float, precision=8)
+                elTable.variables.pfPuID = LazyVar("? pfCluster.isNonnull ? pfCluster.egVsPUMVAOut : -1", float, precision=8)
+                elTable.variables.clPt   = LazyVar("? pfCluster.isNonnull ? pfCluster.pt : -1", float, precision=8)
+                elTable.variables.clEmEt = LazyVar("? pfCluster.isNonnull ? pfCluster.emEt : -1", float, precision=8)
             elif pdgId == 22:
                 phTable = pfLepTable.clone(
                             cut  = cms.string("abs(pdgId) == %d && pt > 8" % pdgId),
                             name = cms.string(w+"Ph"+postfix))
-                phTable.variables.hwEmID = Var("hwEmID", int)
-                phTable.variables.pfPuID = Var("? pfCluster.isNonnull ? pfCluster.egVsPUMVAOut : -1", float, precision=8)
-                elTable.variables.pfEmID = Var("? pfCluster.isNonnull ? pfCluster.egVsPionMVAOut : -1", float, precision=8)
-                elTable.variables.clPt   = Var("? pfCluster.isNonnull ? pfCluster.pt : -1", float, precision=8)
-                elTable.variables.clEmEt = Var("? pfCluster.isNonnull ? pfCluster.emEt : -1", float, precision=8)
+                phTable.variables.hwEmID = LazyVar("hwEmID", int)
+                phTable.variables.pfPuID = LazyVar("? pfCluster.isNonnull ? pfCluster.egVsPUMVAOut : -1", float, precision=8)
+                elTable.variables.pfEmID = LazyVar("? pfCluster.isNonnull ? pfCluster.egVsPionMVAOut : -1", float, precision=8)
+                elTable.variables.clPt   = LazyVar("? pfCluster.isNonnull ? pfCluster.pt : -1", float, precision=8)
+                elTable.variables.clEmEt = LazyVar("? pfCluster.isNonnull ? pfCluster.emEt : -1", float, precision=8)
                 if w == "Puppi":
-                    phTable.variables.puppiW = Var("puppiWeight", float, precision=8)
+                    phTable.variables.puppiW = LazyVar("puppiWeight", float, precision=8)
                 setattr(process, w+"Ph"+postfix+"Table", phTable)
                 process.extraPFStuff.add(phTable)
 
@@ -530,7 +534,7 @@ def addStaEG(postfix=""):
                             pt  = Var("pt",  float,precision=8),
                             phi = Var("phi", float,precision=8),
                             eta  = Var("eta", float,precision=8),
-                            hwQual    = Var("hwQual", int, doc="id"),
+                            hwQual    = LazyVar("hwQual", int, doc="id"),
                         )
                     )
         return staEgTable
@@ -557,26 +561,26 @@ def addTkEG(doL1=False, doL2=True, postfix=""):
                             pt  = Var("pt",  float,precision=8),
                             phi = Var("phi", float,precision=8),
                             eta  = Var("eta", float,precision=8),
-                            hwQual    = Var("hwQual", int, doc="id"),
-                            tkIso   = Var("trkIsol", float, precision=8),
-                            tkIsoPV  = Var("trkIsolPV", float, precision=8),
-                            pfIso   = Var("pfIsol", float, precision=8),
-                            pfIsoPV  = Var("pfIsolPV", float, precision=8),
-                            puppiIso   = Var("puppiIsol", float, precision=8),
-                            puppiIsoPV  = Var("puppiIsolPV", float, precision=8),
+                            hwQual    = LazyVar("hwQual", int, doc="id"),
+                            tkIso   = LazyVar("trkIsol", float, precision=8),
+                            tkIsoPV  = LazyVar("trkIsolPV", float, precision=8),
+                            pfIso   = LazyVar("pfIsol", float, precision=8),
+                            pfIsoPV  = LazyVar("pfIsolPV", float, precision=8),
+                            puppiIso   = LazyVar("puppiIsol", float, precision=8),
+                            puppiIsoPV  = LazyVar("puppiIsolPV", float, precision=8),
                         )
                     )
         tkEleTable = tkEmTable.clone(
                         name = cms.string("TkEle"+slice+postfix),
                         src = cms.InputTag(tkele_inputtag),
                     )
-        tkEleTable.variables.charge = Var("charge", int, doc="charge")
-        tkEleTable.variables.vz     = Var("trkzVtx",  float,precision=8)
-        tkEleTable.variables.tkEta = Var("trkPtr.eta", float,precision=8)
-        tkEleTable.variables.tkPhi = Var("trkPtr.phi", float,precision=8)
-        tkEleTable.variables.tkPt = Var("trkPtr.momentum.perp", float,precision=8)
-        tkEleTable.variables.caloEta = Var("egCaloPtr.eta", float,precision=8)
-        tkEleTable.variables.caloPhi = Var("egCaloPtr.phi", float,precision=8)
+        tkEleTable.variables.charge = LazyVar("charge", int, doc="charge")
+        tkEleTable.variables.vz     = LazyVar("trkzVtx",  float,precision=8)
+        tkEleTable.variables.tkEta = LazyVar("trkPtr.eta", float,precision=8)
+        tkEleTable.variables.tkPhi = LazyVar("trkPtr.phi", float,precision=8)
+        tkEleTable.variables.tkPt = LazyVar("trkPtr.momentum.perp", float,precision=8)
+        tkEleTable.variables.caloEta = LazyVar("egCaloPtr.eta", float,precision=8)
+        tkEleTable.variables.caloPhi = LazyVar("egCaloPtr.phi", float,precision=8)
         return tkEmTable, tkEleTable
                                    
     if doL1:    
@@ -606,15 +610,15 @@ def addDecodedTk(regs=['HGCal','Barrel']):
                             pt  = Var("pt",  float,precision=8),
                             phi = Var("phi", float,precision=8),
                             eta  = Var("eta", float,precision=8),
-                            caloPhi = Var("caloPhi", float,precision=8),
-                            caloEta  = Var("caloEta", float,precision=8),
-                            vz = Var("vz", float,precision=8),
-                            chi2RPhi = Var("trackWord.getChi2RPhi", float,precision=8),
-                            chi2RZ = Var('trackWord.getChi2RZ', float, precision=8),
-                            chi2Bend = Var('trackWord.getBendChi2', float, precision=8),
-                            hitPattern = Var('trackWord.getHitPattern', int),
-                            nStubs = Var('trackWord.getNStubs', int),
-                            mvaQual = Var('trackWord.getMVAQuality', int),
+                            caloPhi = LazyVar("caloPhi", float,precision=8),
+                            caloEta  = LazyVar("caloEta", float,precision=8),
+                            vz = LazyVar("vz", float,precision=8),
+                            chi2RPhi = LazyVar("trackWord.getChi2RPhi", float,precision=8),
+                            chi2RZ = LazyVar('trackWord.getChi2RZ', float, precision=8),
+                            chi2Bend = LazyVar('trackWord.getBendChi2', float, precision=8),
+                            hitPattern = LazyVar('trackWord.getHitPattern', int),
+                            nStubs = LazyVar('trackWord.getNStubs', int),
+                            mvaQual = LazyVar('trackWord.getMVAQuality', int),
                         )
                     )
         setattr(process, f"decTk{reg}Table", decTkTable)
@@ -632,24 +636,24 @@ def addEGCrystalClusters() -> None:
                                         singleton = cms.bool(False), # the number of entries is variable
                                         extension = cms.bool(False), # this is the main table
                                         variables = cms.PSet(
-                                            isolation  = Var("isolation", float,precision=8),
+                                            isolation  = LazyVar("isolation", float,precision=8),
                                             pt  = Var("pt",  float,precision=8),
                                             eta  = Var("eta", float,precision=8),
                                             phi = Var("phi", float,precision=8),
-                                            calibratedPt = Var("calibratedPt", float,precision=8),
-                                            hovere = Var("hovere", float,precision=8),
-                                            puCorrPt = Var("puCorrPt", float,precision=8),
-                                            bremStrength = Var("bremStrength", float,precision=8),
-                                            e2x2 = Var("e2x2", float,precision=8),
-                                            e2x5 = Var("e2x5", float,precision=8),
-                                            e3x5 = Var("e3x5", float,precision=8),
-                                            e5x5 = Var("e5x5", float,precision=8),
-                                            standaloneWP = Var("standaloneWP", int,precision=8),
-                                            electronWP98 = Var("electronWP98", int,precision=8),
-                                            photonWP80 = Var("photonWP80", int,precision=8),
-                                            electronWP90 = Var("electronWP90", int,precision=8),
-                                            looseL1TkMatchWP = Var("looseL1TkMatchWP", int,precision=8),
-                                            stage2effMatch= Var("stage2effMatch", int,precision=8),
+                                            calibratedPt = LazyVar("calibratedPt", float,precision=8),
+                                            hovere = LazyVar("hovere", float,precision=8),
+                                            puCorrPt = LazyVar("puCorrPt", float,precision=8),
+                                            bremStrength = LazyVar("bremStrength", float,precision=8),
+                                            e2x2 = LazyVar("e2x2", float,precision=8),
+                                            e2x5 = LazyVar("e2x5", float,precision=8),
+                                            e3x5 = LazyVar("e3x5", float,precision=8),
+                                            e5x5 = LazyVar("e5x5", float,precision=8),
+                                            standaloneWP = LazyVar("standaloneWP", int,precision=8),
+                                            electronWP98 = LazyVar("electronWP98", int,precision=8),
+                                            photonWP80 = LazyVar("photonWP80", int,precision=8),
+                                            electronWP90 = LazyVar("electronWP90", int,precision=8),
+                                            looseL1TkMatchWP = LazyVar("looseL1TkMatchWP", int,precision=8),
+                                            stage2effMatch= LazyVar("stage2effMatch", int,precision=8),
                                         )
             )
         return CrystalClustersTable

--- a/NtupleProducer/python/scouting/runJetStudyNTuple.py
+++ b/NtupleProducer/python/scouting/runJetStudyNTuple.py
@@ -97,7 +97,7 @@ process.puppiExtJetsTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         )
 )
 
-process.genParticleTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+process.genParticleTable = cms.EDProducer("SimpleGenParticleFlatTableProducer",
         name = cms.string("GenParticles"),
         cut  = cms.string("abs(eta) < 5"),
         src = cms.InputTag("genParticlesForMETAllVisible"),
@@ -115,7 +115,7 @@ process.genParticleTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         )
 )
 
-process.genVertexTable = cms.EDProducer("SimpleXYZPointFlatTableProducer",
+process.genVertexTable = cms.EDProducer("SimpleGenParticleFlatTableProducer",
     src = cms.InputTag("genParticles:xyz0"),
     cut = cms.string(""),
     name= cms.string("GenVtx"),
@@ -189,7 +189,7 @@ process.genMu = cms.EDFilter("GenParticleSelector",
     cut = cms.string("abs(pdgId) = 13 && status == 1 && pt > 0.5 && abs(eta) < 2.7"),
 )
 
-process.genMuTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+process.genMuTable = cms.EDProducer("SimpleGenParticleFlatTableProducer",
     src = cms.InputTag("genMu"),
     cut = cms.string(""),
     name = cms.string("GenMu"),
@@ -291,7 +291,7 @@ def isSignal():
             "keep+ 9900001 <= abs(pdgId) <= 9900008",
         )
     )
-    process.genHardParticleTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+    process.genHardParticleTable = cms.EDProducer("SimpleGenParticleFlatTableProducer",
             name = cms.string("GenHard"),
             cut  = cms.string(""),
             src = cms.InputTag("genHard"),

--- a/NtupleProducer/python/scouting/runL1BinaryDumpers_cfg.py
+++ b/NtupleProducer/python/scouting/runL1BinaryDumpers_cfg.py
@@ -105,7 +105,7 @@ process.genMu = cms.EDFilter("GenParticleSelector",
     cut = cms.string("abs(pdgId) = 13 && status == 1 && pt > 0.5 && abs(eta) < 2.7"),
 )
 
-process.genMuTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+process.genMuTable = cms.EDProducer("SimpleGenParticleFlatTableProducer",
     src = cms.InputTag("genMu"),
     cut = cms.string(""),
     name = cms.string("GenMu"),
@@ -175,7 +175,7 @@ process.genPiFromW = cms.EDFilter("GenParticleSelector",
         src = cms.InputTag("genParticles"),
         cut = cms.string("abs(pdgId) = 211 && numberOfMothers > 0 && abs(motherRef.pdgId) = 24"),
 )
-process.genWTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+process.genWTable = cms.EDProducer("SimpleGenParticleFlatTableProducer",
                 src = cms.InputTag("genW"),
                 cut = cms.string(""),
                 name = cms.string("GenW"),
@@ -192,7 +192,7 @@ process.genWTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
                     pdgId  = Var("pdgId", int, doc="PDG id"),
                 )
             )
-process.genPiTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+process.genPiTable = cms.EDProducer("SimpleGenParticleFlatTableProducer",
                 src = cms.InputTag("genPiFromW"),
                 cut = cms.string(""),
                 name = cms.string("GenPi"),
@@ -337,7 +337,7 @@ process.genPho = cms.EDFilter("GenParticleSelector",
 process.genEle = process.genPho.clone(
     cut = "pdgId == 11 && status == 1",
 )
-process.genPhoTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+process.genPhoTable = cms.EDProducer("SimpleGenParticleFlatTableProducer",
     src = cms.InputTag("genPho"),
     cut = cms.string(""),
     name = cms.string("GenPho"),

--- a/NtupleProducer/python/scouting/runMuNTuple_cfg.py
+++ b/NtupleProducer/python/scouting/runMuNTuple_cfg.py
@@ -72,7 +72,7 @@ process.genMu = cms.EDFilter("GenParticleSelector",
     cut = cms.string("abs(pdgId) = 13 && status == 1 && pt > 0.5 && abs(eta) < 2.7"),
 )
 
-process.genMuTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+process.genMuTable = cms.EDProducer("SimpleGenParticleFlatTableProducer",
     src = cms.InputTag("genMu"),
     cut = cms.string(""),
     name = cms.string("GenMu"),

--- a/NtupleProducer/python/scouting/runW3PiNtuples_cfg.py
+++ b/NtupleProducer/python/scouting/runW3PiNtuples_cfg.py
@@ -79,7 +79,7 @@ def goSignal():
             src = cms.InputTag("genParticles"),
             cut = cms.string("abs(pdgId) = 211 && numberOfMothers > 0 && abs(motherRef.pdgId) = 24"),
     )
-    process.genWTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+    process.genWTable = cms.EDProducer("SimpleGenParticleFlatTableProducer",
                     src = cms.InputTag("genW"),
                     cut = cms.string(""),
                     name = cms.string("GenW"),
@@ -96,7 +96,7 @@ def goSignal():
                         pdgId  = Var("pdgId", int, doc="PDG id"),
                     )
                 )
-    process.genPiTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+    process.genPiTable = cms.EDProducer("SimpleGenParticleFlatTableProducer",
                     src = cms.InputTag("genPiFromW"),
                     cut = cms.string(""),
                     name = cms.string("GenPi"),

--- a/NtupleProducer/test/test_runPerformanceNtuple_cfg.py
+++ b/NtupleProducer/test/test_runPerformanceNtuple_cfg.py
@@ -1,0 +1,23 @@
+import FWCore.ParameterSet.Config as cms
+
+from FastPUPPI.NtupleProducer.runPerformanceNTuple import *
+
+noResp();
+addGenLep([11,22]);
+addTkEG(); # done
+addHGCalTPs() # done
+addStaEG() # done
+noResp()
+addDecodedTk(); # done
+addEGCrystalClusters(); # done
+# addSeededConeJets(); # done
+addTkJets();
+addStaMu();
+addPFLep();
+
+
+process.maxEvents.input = cms.untracked.int32(100)
+process.source.fileNames = cms.untracked.vstring('root://eoscms.cern.ch//eos/cms/store/cmst3/group/l1tr/FastPUPPI/14_0_X/fpinputs_131X/v9a/DoubleElectron_FlatPt-1To100_PU200/inputs131X_1.root',
+'root://eoscms.cern.ch//eos/cms/store/cmst3/group/l1tr/FastPUPPI/14_0_X/fpinputs_131X/v9a/DoubleElectron_FlatPt-1To100_PU200/inputs131X_10.root')
+process.outnano.fileName = cms.untracked.string('perfNano.root')
+


### PR DESCRIPTION
Enables running NttupleProduction in 14.2.X using lazy evaluation where needed.

This is on top of #73 