### PR TITLE
Add function addNNPuppiTau() to add Tau Lepton information

### DIFF
--- a/NtupleProducer/python/runPerformanceNTuple.py
+++ b/NtupleProducer/python/runPerformanceNTuple.py
@@ -251,7 +251,7 @@ def addCalib():
 
 def addNNPuppiTaus():
     process.extraPFStuff.add(process.l1tNNTauProducerPuppi)
-    process.l1pfjetTable.jets.l1tau = cms.InputTag('l1tNNTauProducerPuppi', "L1PFTausNN")
+    process.l1pfjetTable.jets.nnPuppiTau = cms.InputTag('l1tNNTauProducerPuppi', "L1PFTausNN")
 
 def addSeededConeJets():
     process.extraPFStuff.add(process.L1TPFJetsTask)

--- a/NtupleProducer/python/runPerformanceNTuple.py
+++ b/NtupleProducer/python/runPerformanceNTuple.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
-from PhysicsTools.NanoAOD.common_cff import Var, ExtVar 
+from PhysicsTools.NanoAOD.common_cff import Var, ExtVar
 
 process = cms.Process("RESP", eras.Phase2C17I13M9)
 
@@ -41,6 +41,9 @@ process.l1tTrackSelectionProducer.processSimulatedTracks = False
 
 from L1Trigger.L1CaloTrigger.l1tPhase2L1CaloEGammaEmulator_cfi import l1tPhase2L1CaloEGammaEmulator
 process.l1tPhase2L1CaloEGammaEmulator = l1tPhase2L1CaloEGammaEmulator.clone()
+
+from L1Trigger.Phase2L1ParticleFlow.L1NNTauProducer_cff import l1tNNTauProducerPuppi
+process.l1tNNTauProducerPuppi = l1tNNTauProducerPuppi.clone()
 
 process.extraPFStuff = cms.Task(
         process.l1tPhase2L1CaloEGammaEmulator,
@@ -195,6 +198,7 @@ if True:
     process.ntuple.objects.PhGenAcc = cms.VInputTag(cms.InputTag("genInAcceptance"))
     process.ntuple.objects.PhGenAcc_sel = cms.string("pdgId == 22")
     process.extraPFStuff.add(process.genInAcceptance)
+
 def respOnly():
     process.p.remove(process.l1pfjetTable)
     process.p.remove(process.l1pfmetTable)
@@ -244,6 +248,10 @@ def addCalib():
     process.ntuple.objects.L1HGCal   = cms.VInputTag('l1tPFClustersFromHGC3DClusters')
     process.ntuple.objects.L1HFCalo  = cms.VInputTag('l1tPFClustersFromCombinedCaloHF:calibrated')
     process.ntuple.objects.L1HGCalEM = cms.VInputTag('l1tPFClustersFromHGC3DClustersEM', )
+
+def addNNPuppiTaus():
+    process.extraPFStuff.add(process.l1tNNTauProducerPuppi)
+    process.l1pfjetTable.jets.l1tau = cms.InputTag('l1tNNTauProducerPuppi', "L1PFTausNN")
 
 def addSeededConeJets():
     process.extraPFStuff.add(process.L1TPFJetsTask)


### PR DESCRIPTION
Added Function:
def addNNPuppiTaus():
    process.extraPFStuff.add(process.l1tNNTauProducerPuppi)
    process.l1pfjetTable.jets.l1tau = cms.InputTag('l1tNNTauProducerPuppi', "L1PFTausNN")

Into runPerformanceNTuple.py 
Adds information on tau leptons to the collection.
Could be useful for processes like GG->HH->bbtautau