### PR TITLE
Adapt to new PFCluster format and add decoded calo info

### DIFF
--- a/NtupleProducer/plugins/L1HGC3DclTableProducer.cc
+++ b/NtupleProducer/plugins/L1HGC3DclTableProducer.cc
@@ -93,18 +93,15 @@ L1HGC3DclTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
     for (unsigned int i = 0; i < ncands; ++i) {
         auto cl3d = *selected[i];
 
-        l1t::PFCluster cluster;
         bool passEmVsPU = false;
         bool passPFEmVsPion = false;
         if (!emVsPUID_.method().empty()) {
-            passEmVsPU = emVsPUID_.passID(cl3d, cluster);
+            passEmVsPU = emVsPUID_.passID(cl3d, vals_puid[i]);
         }
         if (!emVsPionID_.method().empty()) {
-            passPFEmVsPion = emVsPionID_.passID(cl3d, cluster);
+            passPFEmVsPion = emVsPionID_.passID(cl3d, vals_pfemid[i]);
         }
 
-        vals_puid[i] = cluster.egVsPUMVAOut();
-        vals_pfemid[i] = cluster.egVsPionMVAOut();
         vals_egemid[i] = id_->value(cl3d);
         pass_puid[i] = passEmVsPU;
         pass_pfemid[i] = passPFEmVsPion;

--- a/NtupleProducer/plugins/L1PFDecodedCaloTableProducer.cc
+++ b/NtupleProducer/plugins/L1PFDecodedCaloTableProducer.cc
@@ -1,0 +1,135 @@
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "DataFormats/L1TParticleFlow/interface/PFCluster.h"
+#include "DataFormats/L1TCalorimeterPhase2/interface/CaloCrystalCluster.h"
+
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "CommonTools/Utils/interface/StringObjectFunction.h"
+
+
+#include <algorithm>
+
+class L1PFDecodedCaloTableProducer : public edm::global::EDProducer<>  {
+    public:
+        explicit L1PFDecodedCaloTableProducer(const edm::ParameterSet&);
+        ~L1PFDecodedCaloTableProducer();
+
+    private:
+        virtual void produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+
+
+        std::string name_;
+        edm::EDGetTokenT<l1t::PFClusterCollection> clusters_;
+        StringCutObjectSelector<l1t::PFCluster> sel_;
+
+};
+
+L1PFDecodedCaloTableProducer::L1PFDecodedCaloTableProducer(const edm::ParameterSet& iConfig) :
+    name_(iConfig.getParameter<std::string>("name")),
+    clusters_(consumes<l1t::PFClusterCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+    sel_(iConfig.getParameter<std::string>("cut"), true)
+{
+    produces<nanoaod::FlatTable>();
+
+}
+
+L1PFDecodedCaloTableProducer::~L1PFDecodedCaloTableProducer() { }
+
+// ------------ method called for each event  ------------
+    void
+L1PFDecodedCaloTableProducer::produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSetup& iSetup) const
+{
+    edm::Handle<l1t::PFClusterCollection> clusters;
+    iEvent.getByToken(clusters_, clusters);
+
+    std::vector<const l1t::PFCluster *> selected;
+
+
+    for (const l1t::PFCluster &cl : *clusters)
+        if(sel_(cl)) selected.push_back(&cl);
+
+    
+    // create the table
+    unsigned int ncands = selected.size();
+    auto out = std::make_unique<nanoaod::FlatTable>(ncands, name_, false, true);
+
+    std::vector<float> vals_empt, vals_srrTot, vals_hwSrrTot, vals_meanz, vals_hwMeanZ, vals_hoe, vals_piIdProb, vals_PuIdProb, vals_EmIdProb, vals_caloIso, vals_showerShape; 
+    vals_empt.resize(ncands);
+    vals_srrTot.resize(ncands);
+    vals_hwSrrTot.resize(ncands);
+    vals_meanz.resize(ncands);
+    vals_hwMeanZ.resize(ncands);
+    vals_hoe.resize(ncands);
+    vals_piIdProb.resize(ncands);
+    vals_PuIdProb.resize(ncands);
+    vals_EmIdProb.resize(ncands);
+    vals_caloIso.resize(ncands);
+    vals_showerShape.resize(ncands);
+    
+    for (unsigned int i = 0; i < ncands; ++i) {
+        const auto cand = selected[i];
+        auto obj = cand->caloDigiObj();
+
+        if(auto digi = std::get_if<l1ct::EmCaloObj>(&obj)){
+            vals_srrTot[i] =   digi->floatSrrTot();
+            vals_hwSrrTot[i] = digi->hwSrrTot.to_float();
+            vals_meanz[i] =    digi->floatMeanZ();
+            vals_hwMeanZ[i] =  digi->hwMeanZ.to_float();
+            vals_hoe[i] =      digi->floatHoe();
+            vals_piIdProb[i] = digi->floatPiProb();
+            vals_PuIdProb[i] = digi->floatPuProb();
+            vals_EmIdProb[i] = digi->floatEmProb();
+
+            const l1tp2::CaloCrystalCluster *crycl = dynamic_cast<const l1tp2::CaloCrystalCluster *>(cand->constituentsAndFractions().front().first.get());
+            if(crycl) {
+                vals_caloIso[i] = crycl->isolation();
+                vals_showerShape[i] = crycl->e2x5() / crycl->e5x5();
+            }
+        } else if(auto digi = std::get_if<l1ct::HadCaloObj>(&obj)){
+            vals_empt[i] = digi->floatEmPt();
+
+            vals_srrTot[i] = digi->floatSrrTot();
+            vals_hwSrrTot[i] = digi->hwSrrTot.to_float();
+            vals_meanz[i] = digi->floatMeanZ();
+            vals_hwMeanZ[i] = digi->hwMeanZ.to_float();
+            vals_hoe[i] = digi->floatHoe();
+            vals_piIdProb[i] = digi->floatPiProb();
+            vals_PuIdProb[i] = digi->floatPuProb();
+            vals_EmIdProb[i] = digi->floatEmProb();
+
+        }
+    }
+
+
+    out->addColumn<float>("empt", vals_empt, "");
+    out->addColumn<float>("srrTot", vals_srrTot, "");
+    out->addColumn<float>("hwSrrTot", vals_hwSrrTot, "");
+    out->addColumn<float>("meanz", vals_meanz, "");
+    out->addColumn<float>("hwMeanZ", vals_hwMeanZ, "");
+    out->addColumn<float>("hoe", vals_hoe, "");
+    out->addColumn<float>("piIdProb", vals_piIdProb, "");
+    out->addColumn<float>("PuIdProb", vals_PuIdProb, "");
+    out->addColumn<float>("EmIdProb", vals_EmIdProb, "");
+    out->addColumn<float>("caloIso", vals_caloIso, "");
+    out->addColumn<float>("showerShape", vals_showerShape, "");
+
+    // save to the event branches
+    iEvent.put(std::move(out));
+
+   
+}
+
+//define this as a plug-in
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(L1PFDecodedCaloTableProducer);

--- a/NtupleProducer/plugins/L1PFDecodedCaloTableProducer.cc
+++ b/NtupleProducer/plugins/L1PFDecodedCaloTableProducer.cc
@@ -7,6 +7,7 @@
 
 #include "DataFormats/L1TParticleFlow/interface/PFCluster.h"
 #include "DataFormats/L1TCalorimeterPhase2/interface/CaloCrystalCluster.h"
+#include "DataFormats/L1THGCal/interface/HGCalMulticluster.h"
 
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -64,7 +65,16 @@ L1PFDecodedCaloTableProducer::produce(edm::StreamID id, edm::Event& iEvent, cons
     unsigned int ncands = selected.size();
     auto out = std::make_unique<nanoaod::FlatTable>(ncands, name_, false, true);
 
-    std::vector<float> vals_empt, vals_srrTot, vals_hwSrrTot, vals_meanz, vals_hwMeanZ, vals_hoe, vals_piIdProb, vals_PuIdProb, vals_EmIdProb, vals_caloIso, vals_showerShape; 
+    std::vector<float> vals_empt, vals_srrTot, vals_hwSrrTot, vals_meanz, 
+        vals_hwMeanZ, vals_hoe, vals_piIdProb, vals_PuIdProb, vals_EmIdProb, 
+        vals_caloIso, vals_showerShape; 
+     std::vector<float> vals_showerlength,
+        vals_coreshowerlength, vals_emf, vals_hw_emf, vals_abseta, 
+        vals_hw_abseta, 
+        vals_hw_meanz, 
+        vals_sigmaetaeta, vals_hw_sigmaetaeta, 
+        vals_sigmaphiphi, vals_hw_sigmaphiphi, vals_sigmazz, vals_hw_sigmazz;
+
     vals_empt.resize(ncands);
     vals_srrTot.resize(ncands);
     vals_hwSrrTot.resize(ncands);
@@ -76,7 +86,21 @@ L1PFDecodedCaloTableProducer::produce(edm::StreamID id, edm::Event& iEvent, cons
     vals_EmIdProb.resize(ncands);
     vals_caloIso.resize(ncands);
     vals_showerShape.resize(ncands);
-    
+    vals_showerlength.resize(ncands);
+    vals_coreshowerlength.resize(ncands);
+    vals_emf.resize(ncands);
+    vals_hw_emf.resize(ncands);
+    vals_abseta.resize(ncands);
+    vals_hw_abseta.resize(ncands);
+    vals_hw_meanz.resize(ncands);
+    vals_sigmaetaeta.resize(ncands);
+    vals_hw_sigmaetaeta.resize(ncands);
+    vals_sigmaphiphi.resize(ncands);
+    vals_hw_sigmaphiphi.resize(ncands);
+    vals_sigmazz.resize(ncands);
+    vals_hw_sigmazz.resize(ncands);
+
+
     for (unsigned int i = 0; i < ncands; ++i) {
         const auto cand = selected[i];
         auto obj = cand->caloDigiObj();
@@ -108,6 +132,37 @@ L1PFDecodedCaloTableProducer::produce(edm::StreamID id, edm::Event& iEvent, cons
             vals_PuIdProb[i] = digi->floatPuProb();
             vals_EmIdProb[i] = digi->floatEmProb();
 
+            const l1t::HGCalMulticluster *hgcalcl = dynamic_cast<const l1t::HGCalMulticluster *>(cand->constituentsAndFractions().front().first.get());
+            if(hgcalcl) {
+                static constexpr float ETAPHI_LSB = M_PI / 720;
+                static constexpr float SIGMAZZ_LSB = 778.098 / (1 << 7);
+                static constexpr float SIGMAPHIPHI_LSB = 0.12822 / (1 << 7);
+                static constexpr float SIGMAETAETA_LSB = 0.148922 / (1 << 5);
+
+                ap_uint<6> w_showerlenght = hgcalcl->showerLength();
+                ap_uint<6> w_coreshowerlenght = hgcalcl->coreShowerLength();
+                ap_uint<8> w_emf = std::min(round(hgcalcl->eot() * 256), float(255.));
+                ap_uint<10> w_abseta = round(fabs(hgcalcl->eta()) / ETAPHI_LSB);
+                ap_ufixed<12, 11, AP_RND_CONV, AP_SAT> w_meanz_f = fabs(hgcalcl->zBarycenter()) - 320;  // LSB = 0.5cm
+                ap_uint<12> w_meanz = w_meanz_f.range();
+                ap_uint<5> w_sigmaetaeta = round(hgcalcl->sigmaEtaEtaTot() / SIGMAETAETA_LSB);
+                ap_uint<7> w_sigmaphiphi = round(hgcalcl->sigmaPhiPhiTot() / SIGMAPHIPHI_LSB);
+                ap_uint<7> w_sigmazz = round(hgcalcl->sigmaZZ() / SIGMAZZ_LSB);
+
+                vals_showerlength[i] = w_showerlenght.to_int();
+                vals_coreshowerlength[i] = w_coreshowerlenght.to_int();
+                vals_emf[i] = w_emf / 256.;
+                vals_hw_emf[i] = w_emf.to_float();
+                vals_abseta[i] = w_abseta * ETAPHI_LSB;
+                vals_hw_abseta[i] = w_abseta.to_float();
+                vals_hw_meanz[i] = w_meanz*0.5;
+                vals_sigmaetaeta[i] = w_sigmaetaeta * SIGMAETAETA_LSB;
+                vals_hw_sigmaetaeta[i] = w_sigmaetaeta.to_float();
+                vals_sigmaphiphi[i] = w_sigmaphiphi * SIGMAPHIPHI_LSB;
+                vals_hw_sigmaphiphi[i] = w_sigmaphiphi.to_float();
+                vals_sigmazz[i] = w_sigmazz * SIGMAZZ_LSB;
+                vals_hw_sigmazz[i] = w_sigmazz.to_float();
+            }
         }
     }
 
@@ -123,6 +178,20 @@ L1PFDecodedCaloTableProducer::produce(edm::StreamID id, edm::Event& iEvent, cons
     out->addColumn<float>("EmIdProb", vals_EmIdProb, "");
     out->addColumn<float>("caloIso", vals_caloIso, "");
     out->addColumn<float>("showerShape", vals_showerShape, "");
+
+    out->addColumn<float>("showerlength", vals_showerlength, "");
+    out->addColumn<float>("coreshowerlength", vals_coreshowerlength, "");
+    out->addColumn<float>("emf", vals_emf, "");
+    out->addColumn<float>("hwEmf", vals_hw_emf, "");
+    out->addColumn<float>("abseta", vals_abseta, "");
+    out->addColumn<float>("hwAbseta", vals_hw_abseta, "");
+    out->addColumn<float>("hwFPMeanz", vals_hw_meanz, "");    
+    out->addColumn<float>("sigmaetaeta", vals_sigmaetaeta, "");
+    out->addColumn<float>("hwSigmaetaeta", vals_hw_sigmaetaeta, "");
+    out->addColumn<float>("sigmaphiphi", vals_sigmaphiphi, "");
+    out->addColumn<float>("hwSigmaphiphi", vals_hw_sigmaphiphi, "");
+    out->addColumn<float>("sigmazz", vals_sigmazz, "");
+    out->addColumn<float>("hwSigmazz", vals_hw_sigmazz, "");
 
     // save to the event branches
     iEvent.put(std::move(out));

--- a/NtupleProducer/python/runInputs140X.py
+++ b/NtupleProducer/python/runInputs140X.py
@@ -25,8 +25,9 @@ process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
         # 'file:/data/cerminar/Phase2Spring23DIGIRECOMiniAOD/DoubleElectron_FlatPt-1To100-gun/GEN-SIM-DIGI-RAW-MINIAOD/PU200_Trk1GeV_131X_mcRun4_realistic_v5-v1/c699a773-9875-40c9-83b7-5a3c27f90bfd.root',
-        '/store/mc/Phase2Spring24DIGIRECOMiniAOD/TTToSemileptonic_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_Trk1GeV_140X_mcRun4_realistic_v4-v2/2820000/5b6178a7-19bf-4f7f-af63-5bab03393e54.root',        
+        # '/store/mc/Phase2Spring24DIGIRECOMiniAOD/TTToSemileptonic_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_Trk1GeV_140X_mcRun4_realistic_v4-v2/2820000/5b6178a7-19bf-4f7f-af63-5bab03393e54.root',        
         # '/store/mc/Phase2Spring23DIGIRECOMiniAOD/MinBias_TuneCP5_14TeV-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_Trk1GeV_131X_mcRun4_realistic_v5-v1/30002/3b44d52d-1807-4a4f-9b9b-19466303a741.root',
+'/store/mc/Phase2Spring24DIGIRECOMiniAOD/SingleElectron_Pt-2To200-gun/GEN-SIM-DIGI-RAW-MINIAOD/PU200_Trk1GeV_140X_mcRun4_realistic_v4-v1/2560000/c598c5a7-d4d8-489d-bbc7-43fe9aa6b350.root'
 ),
 
     inputCommands = cms.untracked.vstring(
@@ -35,7 +36,8 @@ process.source = cms.Source("PoolSource",
         # 'drop l1tPFTaus_*_*_*',
         # 'drop l1tTrackerMuons_*_*_*',
         'drop *_hlt*_*_HLT',
-        'drop triggerTriggerFilterObjectWithRefs_*_*_HLT'
+        'drop triggerTriggerFilterObjectWithRefs_*_*_HLT',
+        'drop *_l1tLayer*_*_HLT',
     ),
 )
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(20))

--- a/NtupleProducer/python/runPerformanceNTuple.py
+++ b/NtupleProducer/python/runPerformanceNTuple.py
@@ -583,12 +583,14 @@ def addTkEG(doL1=False, doL2=True, postfix=""):
                         src = cms.InputTag(tkele_inputtag),
                     )
         tkEleTable.variables.charge = LazyVar("charge", int, doc="charge")
+        tkEleTable.variables.idScore = LazyVar("idScore", float,precision=8)
         tkEleTable.variables.vz     = LazyVar("trkzVtx",  float,precision=8)
         tkEleTable.variables.tkEta = LazyVar("trkPtr.eta", float,precision=8)
         tkEleTable.variables.tkPhi = LazyVar("trkPtr.phi", float,precision=8)
         tkEleTable.variables.tkPt = LazyVar("trkPtr.momentum.perp", float,precision=8)
         tkEleTable.variables.caloEta = LazyVar("egCaloPtr.eta", float,precision=8)
         tkEleTable.variables.caloPhi = LazyVar("egCaloPtr.phi", float,precision=8)
+
         return tkEmTable, tkEleTable
                                    
     if doL1:    

--- a/NtupleProducer/python/runPerformanceNTuple.py
+++ b/NtupleProducer/python/runPerformanceNTuple.py
@@ -46,11 +46,19 @@ process.l1tTrackSelectionProducer.processSimulatedTracks = False
 from L1Trigger.L1CaloTrigger.l1tPhase2L1CaloEGammaEmulator_cfi import l1tPhase2L1CaloEGammaEmulator
 process.l1tPhase2L1CaloEGammaEmulator = l1tPhase2L1CaloEGammaEmulator.clone()
 
+from L1Trigger.L1CaloTrigger.l1tPhase2CaloPFClusterEmulator_cfi import l1tPhase2CaloPFClusterEmulator
+process.l1tPhase2CaloPFClusterEmulator = l1tPhase2CaloPFClusterEmulator.clone()
+
+from L1Trigger.L1CaloTrigger.l1tPhase2GCTBarrelToCorrelatorLayer1Emulator_cfi import l1tPhase2GCTBarrelToCorrelatorLayer1Emulator
+process.l1tPhase2GCTBarrelToCorrelatorLayer1Emulator = l1tPhase2GCTBarrelToCorrelatorLayer1Emulator.clone()
+
 from L1Trigger.Phase2L1ParticleFlow.L1NNTauProducer_cff import l1tNNTauProducerPuppi
 process.l1tNNTauProducerPuppi = l1tNNTauProducerPuppi.clone()
 
 process.extraPFStuff = cms.Task(
         process.l1tPhase2L1CaloEGammaEmulator,
+        process.l1tPhase2CaloPFClusterEmulator,
+        process.l1tPhase2GCTBarrelToCorrelatorLayer1Emulator,
         process.l1tSAMuonsGmt,
         process.l1tGTTInputProducer,
         process.l1tTrackSelectionProducer,
@@ -231,27 +239,27 @@ def addCHS():
     process.extraPFStuff.add(process.l1PuppiCharged, process.l1PFNeutral)
     monitorPerf("L1CHS", [ "l1PuppiCharged", "l1PFNeutral" ], makeRespSplit = False)
 
-def addCalib():
-    process.load("L1Trigger.Phase2L1ParticleFlow.l1tPFClustersFromHGC3DClustersEM_cfi")
-    process.l1tPFClustersFromL1EGClustersRaw    = process.l1tPFClustersFromL1EGClusters.clone(corrector = "")
-    process.l1tPFClustersFromHGC3DClustersRaw   = process.l1tPFClustersFromHGC3DClusters.clone(corrector = "")
-    process.l1tPFClustersFromHGC3DClustersEMRaw = process.l1tPFClustersFromHGC3DClustersEM.clone(corrector = "")
-    process.extraPFStuff.add(
-            process.l1tPFClustersFromL1EGClustersRaw, 
-            process.l1tPFClustersFromHGC3DClustersRaw, 
-            process.l1tPFClustersFromHGC3DClustersEM,
-            process.l1tPFClustersFromHGC3DClustersEMRaw)
-    process.ntuple.objects.L1RawBarrelEcal   = cms.VInputTag('l1tPFClustersFromL1EGClustersRaw' )
-    process.ntuple.objects.L1RawBarrelCalo   = cms.VInputTag('l1tPFClustersFromCombinedCaloHCal:uncalibrated')
-    process.ntuple.objects.L1RawBarrelCaloEM = cms.VInputTag('l1tPFClustersFromCombinedCaloHCal:emUncalibrated')
-    process.ntuple.objects.L1RawHGCal   = cms.VInputTag('l1tPFClustersFromHGC3DClustersRaw')
-    process.ntuple.objects.L1RawHGCalEM = cms.VInputTag('l1tPFClustersFromHGC3DClustersEMRaw')
-    process.ntuple.objects.L1RawHFCalo  = cms.VInputTag('l1tPFClustersFromCombinedCaloHF:uncalibrated')
-    process.ntuple.objects.L1BarrelEcal = cms.VInputTag('l1tPFClustersFromL1EGClusters' )
-    process.ntuple.objects.L1BarrelCalo = cms.VInputTag('l1tPFClustersFromCombinedCaloHCal:calibrated')
-    process.ntuple.objects.L1HGCal   = cms.VInputTag('l1tPFClustersFromHGC3DClusters')
-    process.ntuple.objects.L1HFCalo  = cms.VInputTag('l1tPFClustersFromCombinedCaloHF:calibrated')
-    process.ntuple.objects.L1HGCalEM = cms.VInputTag('l1tPFClustersFromHGC3DClustersEM', )
+# def addCalib():
+#     process.load("L1Trigger.Phase2L1ParticleFlow.l1tPFClustersFromHGC3DClustersEM_cfi")
+#     process.l1tPFClustersFromL1EGClustersRaw    = process.l1tPFClustersFromL1EGClusters.clone(corrector = "")
+#     process.l1tPFClustersFromHGC3DClustersRaw   = process.l1tPFClustersFromHGC3DClusters.clone(corrector = "")
+#     process.l1tPFClustersFromHGC3DClustersEMRaw = process.l1tPFClustersFromHGC3DClustersEM.clone(corrector = "")
+#     process.extraPFStuff.add(
+#             process.l1tPFClustersFromL1EGClustersRaw, 
+#             process.l1tPFClustersFromHGC3DClustersRaw, 
+#             process.l1tPFClustersFromHGC3DClustersEM,
+#             process.l1tPFClustersFromHGC3DClustersEMRaw)
+#     process.ntuple.objects.L1RawBarrelEcal   = cms.VInputTag('l1tPFClustersFromL1EGClustersRaw' )
+#     process.ntuple.objects.L1RawBarrelCalo   = cms.VInputTag('l1tPFClustersFromCombinedCaloHCal:uncalibrated')
+#     process.ntuple.objects.L1RawBarrelCaloEM = cms.VInputTag('l1tPFClustersFromCombinedCaloHCal:emUncalibrated')
+#     process.ntuple.objects.L1RawHGCal   = cms.VInputTag('l1tPFClustersFromHGC3DClustersRaw')
+#     process.ntuple.objects.L1RawHGCalEM = cms.VInputTag('l1tPFClustersFromHGC3DClustersEMRaw')
+#     process.ntuple.objects.L1RawHFCalo  = cms.VInputTag('l1tPFClustersFromCombinedCaloHF:uncalibrated')
+#     process.ntuple.objects.L1BarrelEcal = cms.VInputTag('l1tPFClustersFromL1EGClusters' )
+#     process.ntuple.objects.L1BarrelCalo = cms.VInputTag('l1tPFClustersFromCombinedCaloHCal:calibrated')
+#     process.ntuple.objects.L1HGCal   = cms.VInputTag('l1tPFClustersFromHGC3DClusters')
+#     process.ntuple.objects.L1HFCalo  = cms.VInputTag('l1tPFClustersFromCombinedCaloHF:calibrated')
+#     process.ntuple.objects.L1HGCalEM = cms.VInputTag('l1tPFClustersFromHGC3DClustersEM', )
 
 def addNNPuppiTaus():
     process.extraPFStuff.add(process.l1tNNTauProducerPuppi)
@@ -677,7 +685,7 @@ def addEGCrystalClusters() -> None:
         setattr(process, f"{nameSrcDict['name']}Table", flatTable)
         process.extraPFStuff.add(flatTable)
 
-def addDecodedCalo(types=['Had', 'Em'], regs=['HGCal','Barrel']):
+def addDecodedCalo(types=['Had', 'Em'], regs=['HGCal','Barrel','HGCalNoTK']):
     for tp in types:
         for reg in regs:
             decCaloTable = cms.EDProducer("SimpleCandidateFlatTableProducer",

--- a/NtupleProducer/python/runPerformanceNTuple.py
+++ b/NtupleProducer/python/runPerformanceNTuple.py
@@ -675,6 +675,36 @@ def addEGCrystalClusters() -> None:
         setattr(process, f"{nameSrcDict['name']}Table", flatTable)
         process.extraPFStuff.add(flatTable)
 
+def addDecodedCalo(types=['Had', 'Em'], regs=['HGCal','Barrel']):
+    for tp in types:
+        for reg in regs:
+            decCaloTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+                            name = cms.string(f"Dec{tp}Calo{reg}"),
+                            src = cms.InputTag("l1tLayer1"+reg, f'Decoded{tp}Clusters'),
+                            cut = cms.string(""),
+                            doc = cms.string(""),
+                            singleton = cms.bool(False), # the number of entries is variable
+                            extension = cms.bool(False), # this is the main table
+                            variables = cms.PSet(
+                                pt  = Var("pt",  float,precision=8),
+                                phi = Var("phi", float,precision=8),
+                                eta  = Var("eta", float,precision=8),
+                                hwQual = LazyVar("hwQual", int, doc="id"),
+                                hwEta = LazyVar("hwEta", int, doc="hwEta"),
+                                hwPhi = LazyVar("hwPhi", int, doc="hwPhi"),
+                            )
+                        )            
+
+            decCaloTableExt = cms.EDProducer("L1PFDecodedCaloTableProducer",
+                                             src = cms.InputTag("l1tLayer1"+reg, f'Decoded{tp}Clusters'),
+                                             name = cms.string(""),
+                                             cut = cms.string(""),)
+
+            setattr(process, f"dec{tp}Calo{reg}Table", decCaloTable)
+            setattr(process, f"dec{tp}Calo{reg}ExtTable", decCaloTableExt)
+            decCaloTableExt.name = decCaloTable.name
+            process.extraPFStuff.add(decCaloTable, decCaloTableExt)
+  
 
 def addAllLeps():
     addGenLep()


### PR DESCRIPTION
This PR adapts FP to the CMSSW changes in https://github.com/p2l1pfp/cmssw/pull/129/
Moreover, it exploits the new decoded `PFClusters` objects to add decoded calo info to the ntuples.