### PR TITLE
Added LHE info to input files and perfNano ntuples

### DIFF
--- a/NtupleProducer/python/runInputs110X.py
+++ b/NtupleProducer/python/runInputs110X.py
@@ -54,6 +54,8 @@ process.out = cms.OutputModule("PoolOutputModule",
         outputCommands = cms.untracked.vstring("drop *",
             # --- GEN
             "keep *_genParticles_*_*",
+            "keep *_genFilterEfficiencyProducer_*_*",
+            "keep *_generator_*_*",
             "keep *_externalLHEProducer_*_*",
             "keep *_ak4GenJetsNoNu_*_*",
             "keep *_genMetTrue_*_*",

--- a/NtupleProducer/python/runInputs110X.py
+++ b/NtupleProducer/python/runInputs110X.py
@@ -54,6 +54,7 @@ process.out = cms.OutputModule("PoolOutputModule",
         outputCommands = cms.untracked.vstring("drop *",
             # --- GEN
             "keep *_genParticles_*_*",
+            "keep *_externalLHEProducer_*_*",
             "keep *_ak4GenJetsNoNu_*_*",
             "keep *_genMetTrue_*_*",
             # --- Track TPs

--- a/NtupleProducer/python/runInputs125X.py
+++ b/NtupleProducer/python/runInputs125X.py
@@ -64,6 +64,7 @@ process.out = cms.OutputModule("PoolOutputModule",
         outputCommands = cms.untracked.vstring("drop *",
             # --- GEN
             "keep *_genParticles_*_*",
+            "keep *_externalLHEProducer_*_*",
             "keep *_ak4GenJetsNoNu_*_*",
             "keep *_genMetTrue_*_*",
             # --- Track TPs

--- a/NtupleProducer/python/runInputs125X.py
+++ b/NtupleProducer/python/runInputs125X.py
@@ -64,6 +64,8 @@ process.out = cms.OutputModule("PoolOutputModule",
         outputCommands = cms.untracked.vstring("drop *",
             # --- GEN
             "keep *_genParticles_*_*",
+            "keep *_genFilterEfficiencyProducer_*_*",
+            "keep *_generator_*_*",
             "keep *_externalLHEProducer_*_*",
             "keep *_ak4GenJetsNoNu_*_*",
             "keep *_genMetTrue_*_*",

--- a/NtupleProducer/python/runInputs131X.py
+++ b/NtupleProducer/python/runInputs131X.py
@@ -71,6 +71,7 @@ process.out = cms.OutputModule("PoolOutputModule",
         outputCommands = cms.untracked.vstring("drop *",
             # --- GEN
             "keep *_genParticles_*_*",
+            "keep *_externalLHEProducer_*_*",
             "keep *_ak4GenJetsNoNu_*_*",
             "keep *_genMetTrue_*_*",
             # --- Track TPs

--- a/NtupleProducer/python/runInputs131X.py
+++ b/NtupleProducer/python/runInputs131X.py
@@ -71,6 +71,8 @@ process.out = cms.OutputModule("PoolOutputModule",
         outputCommands = cms.untracked.vstring("drop *",
             # --- GEN
             "keep *_genParticles_*_*",
+            "keep *_genFilterEfficiencyProducer_*_*",
+            "keep *_generator_*_*",
             "keep *_externalLHEProducer_*_*",
             "keep *_ak4GenJetsNoNu_*_*",
             "keep *_genMetTrue_*_*",

--- a/NtupleProducer/python/runInputs140X.py
+++ b/NtupleProducer/python/runInputs140X.py
@@ -74,6 +74,7 @@ process.out = cms.OutputModule("PoolOutputModule",
         outputCommands = cms.untracked.vstring("drop *",
             # --- GEN
             "keep *_genParticles_*_*",
+            "keep *_externalLHEProducer_*_*",
             "keep *_ak4GenJetsNoNu_*_*",
             "keep *_genMetTrue_*_*",
             # --- Track TPs

--- a/NtupleProducer/python/runInputs140X.py
+++ b/NtupleProducer/python/runInputs140X.py
@@ -74,6 +74,8 @@ process.out = cms.OutputModule("PoolOutputModule",
         outputCommands = cms.untracked.vstring("drop *",
             # --- GEN
             "keep *_genParticles_*_*",
+            "keep *_genFilterEfficiencyProducer_*_*",
+            "keep *_generator_*_*",
             "keep *_externalLHEProducer_*_*",
             "keep *_ak4GenJetsNoNu_*_*",
             "keep *_genMetTrue_*_*",

--- a/NtupleProducer/python/runInputs151X.py
+++ b/NtupleProducer/python/runInputs151X.py
@@ -74,6 +74,7 @@ process.out = cms.OutputModule("PoolOutputModule",
         outputCommands = cms.untracked.vstring("drop *",
             # --- GEN
             "keep *_genParticles_*_*",
+            "keep *_externalLHEProducer_*_*",
             "keep *_ak4GenJetsNoNu_*_*",
             "keep *_genMetTrue_*_*",
             # --- Track TPs

--- a/NtupleProducer/python/runInputs151X.py
+++ b/NtupleProducer/python/runInputs151X.py
@@ -74,6 +74,8 @@ process.out = cms.OutputModule("PoolOutputModule",
         outputCommands = cms.untracked.vstring("drop *",
             # --- GEN
             "keep *_genParticles_*_*",
+            "keep *_genFilterEfficiencyProducer_*_*",
+            "keep *_generator_*_*",
             "keep *_externalLHEProducer_*_*",
             "keep *_ak4GenJetsNoNu_*_*",
             "keep *_genMetTrue_*_*",

--- a/NtupleProducer/python/runPerformanceNTuple.py
+++ b/NtupleProducer/python/runPerformanceNTuple.py
@@ -364,6 +364,16 @@ def addTkPtCut(ptCut):
     monitorPerf("L1PFTkPt3", "l1tLayer1TkPt3:PF")
     monitorPerf("L1PuppiTkPt3", "l1tLayer1TkPt3:Puppi")
 
+def addLHEPart():
+    process.lheInfoTable = cms.EDProducer("LHETablesProducer",
+        lheInfo = cms.VInputTag(
+            cms.InputTag("externalLHEProducer"),
+            cms.InputTag("source")
+        ),
+        precision = cms.int32(14),
+        storeLHEParticles = cms.bool(True)
+    )
+    process.extraPFStuff.add(process.lheInfoTable)
 
 def addGen(pdgs):
     genLepTable = cms.EDProducer("SimpleGenParticleFlatTableProducer",


### PR DESCRIPTION
Currently input files lack LHE information (very small in size but can be very useful), which is now added in this PR.

A inline customize function `addLHEPart()` is also added to runPerformanceNtuple.

Should this be backported to older branches? (I am still using 14_2_X to produce input files)