### PR TITLE
Adapt to new GCT objects and add variables for TkEle

### DIFF
--- a/NtupleProducer/plugins/L1PFDecodedCaloTableProducer.cc
+++ b/NtupleProducer/plugins/L1PFDecodedCaloTableProducer.cc
@@ -18,7 +18,6 @@
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 #include "CommonTools/Utils/interface/StringObjectFunction.h"
 
-
 #include <algorithm>
 
 class L1PFDecodedCaloTableProducer : public edm::global::EDProducer<>  {
@@ -67,13 +66,17 @@ L1PFDecodedCaloTableProducer::produce(edm::StreamID id, edm::Event& iEvent, cons
 
     std::vector<float> vals_empt, vals_srrTot, vals_hwSrrTot, vals_meanz, 
         vals_hwMeanZ, vals_hoe, vals_piIdProb, vals_PuIdProb, vals_EmIdProb, 
-        vals_caloIso, vals_showerShape; 
-     std::vector<float> vals_showerlength,
+        vals_caloIso, vals_caloShowerShape, vals_hwEmID, vals_showerShape, 
+        vals_hwShowerShape, vals_hwRelIso, vals_relIso;
+
+    std::vector<float> vals_showerlength,
         vals_coreshowerlength, vals_emf, vals_hw_emf, vals_abseta, 
         vals_hw_abseta, 
         vals_hw_meanz, 
         vals_sigmaetaeta, vals_hw_sigmaetaeta, 
         vals_sigmaphiphi, vals_hw_sigmaphiphi, vals_sigmazz, vals_hw_sigmazz;
+
+    std::vector<float> vals_caloPt, vals_caloEta, vals_caloPhi;
 
     vals_empt.resize(ncands);
     vals_srrTot.resize(ncands);
@@ -85,7 +88,12 @@ L1PFDecodedCaloTableProducer::produce(edm::StreamID id, edm::Event& iEvent, cons
     vals_PuIdProb.resize(ncands);
     vals_EmIdProb.resize(ncands);
     vals_caloIso.resize(ncands);
+    vals_caloShowerShape.resize(ncands);
+    vals_hwEmID.resize(ncands);
     vals_showerShape.resize(ncands);
+    vals_hwShowerShape.resize(ncands);
+    vals_hwRelIso.resize(ncands);
+    vals_relIso.resize(ncands);
     vals_showerlength.resize(ncands);
     vals_coreshowerlength.resize(ncands);
     vals_emf.resize(ncands);
@@ -99,7 +107,9 @@ L1PFDecodedCaloTableProducer::produce(edm::StreamID id, edm::Event& iEvent, cons
     vals_hw_sigmaphiphi.resize(ncands);
     vals_sigmazz.resize(ncands);
     vals_hw_sigmazz.resize(ncands);
-
+    vals_caloPt.resize(ncands);
+    vals_caloEta.resize(ncands);
+    vals_caloPhi.resize(ncands);
 
     for (unsigned int i = 0; i < ncands; ++i) {
         const auto cand = selected[i];
@@ -115,10 +125,23 @@ L1PFDecodedCaloTableProducer::produce(edm::StreamID id, edm::Event& iEvent, cons
             vals_PuIdProb[i] = digi->floatPuProb();
             vals_EmIdProb[i] = digi->floatEmProb();
 
+            vals_hwEmID[i] = digi->hwEmID;
+            vals_showerShape[i] = digi->floatShowerShape();
+            vals_hwShowerShape[i] = digi->hwShowerShape;
+            vals_hwRelIso[i] = digi->hwRelIso;
+            vals_relIso[i] = digi->floatRelIso();
+
+
             const l1tp2::CaloCrystalCluster *crycl = dynamic_cast<const l1tp2::CaloCrystalCluster *>(cand->constituentsAndFractions().front().first.get());
             if(crycl) {
                 vals_caloIso[i] = crycl->isolation();
-                vals_showerShape[i] = crycl->e2x5() / crycl->e5x5();
+                vals_caloShowerShape[i] = crycl->e2x5() / crycl->e5x5();
+                vals_caloPt[i] = crycl->pt();
+                vals_caloEta[i] = crycl->eta();
+                vals_caloPhi[i] = crycl->phi();
+                
+
+
             }
         } else if(auto digi = std::get_if<l1ct::HadCaloObj>(&obj)){
             vals_empt[i] = digi->floatEmPt();
@@ -162,6 +185,13 @@ L1PFDecodedCaloTableProducer::produce(edm::StreamID id, edm::Event& iEvent, cons
                 vals_hw_sigmaphiphi[i] = w_sigmaphiphi.to_float();
                 vals_sigmazz[i] = w_sigmazz * SIGMAZZ_LSB;
                 vals_hw_sigmazz[i] = w_sigmazz.to_float();
+                vals_caloPt[i] = hgcalcl->pt();
+                vals_caloEta[i] = hgcalcl->eta();
+                vals_caloPhi[i] = hgcalcl->phi();
+            } else {
+                vals_caloPt[i] =cand->constituentsAndFractions().front().first.get()->pt();
+                vals_caloEta[i] =cand->constituentsAndFractions().front().first.get()->eta();
+                vals_caloPhi[i] =cand->constituentsAndFractions().front().first.get()->phi();
             }
         }
     }
@@ -176,23 +206,31 @@ L1PFDecodedCaloTableProducer::produce(edm::StreamID id, edm::Event& iEvent, cons
     out->addColumn<float>("piIdProb", vals_piIdProb, "");
     out->addColumn<float>("PuIdProb", vals_PuIdProb, "");
     out->addColumn<float>("EmIdProb", vals_EmIdProb, "");
-    out->addColumn<float>("caloIso", vals_caloIso, "");
+    out->addColumn<float>("srcRelIso", vals_caloIso, "");
+    out->addColumn<float>("srcShowerShape", vals_caloShowerShape, "");
+
+    out->addColumn<float>("hwEmID", vals_hwEmID, "");
     out->addColumn<float>("showerShape", vals_showerShape, "");
+    out->addColumn<float>("hwShowerShape", vals_hwShowerShape, "");
+    out->addColumn<float>("hwRelIso", vals_hwRelIso, "");
+    out->addColumn<float>("relIso", vals_relIso, "");
 
-    out->addColumn<float>("showerlength", vals_showerlength, "");
-    out->addColumn<float>("coreshowerlength", vals_coreshowerlength, "");
-    out->addColumn<float>("emf", vals_emf, "");
-    out->addColumn<float>("hwEmf", vals_hw_emf, "");
-    out->addColumn<float>("abseta", vals_abseta, "");
-    out->addColumn<float>("hwAbseta", vals_hw_abseta, "");
-    out->addColumn<float>("hwFPMeanz", vals_hw_meanz, "");    
-    out->addColumn<float>("sigmaetaeta", vals_sigmaetaeta, "");
-    out->addColumn<float>("hwSigmaetaeta", vals_hw_sigmaetaeta, "");
-    out->addColumn<float>("sigmaphiphi", vals_sigmaphiphi, "");
-    out->addColumn<float>("hwSigmaphiphi", vals_hw_sigmaphiphi, "");
-    out->addColumn<float>("sigmazz", vals_sigmazz, "");
-    out->addColumn<float>("hwSigmazz", vals_hw_sigmazz, "");
-
+    out->addColumn<float>("srcShowerlength", vals_showerlength, "");
+    out->addColumn<float>("srcCoreshowerlength", vals_coreshowerlength, "");
+    out->addColumn<float>("srcEmf", vals_emf, "");
+    out->addColumn<float>("srcHwEmf", vals_hw_emf, "");
+    out->addColumn<float>("srcAbseta", vals_abseta, "");
+    out->addColumn<float>("srcHwAbseta", vals_hw_abseta, "");
+    out->addColumn<float>("srcHwMeanz", vals_hw_meanz, "");    
+    out->addColumn<float>("srcSigmaetaeta", vals_sigmaetaeta, "");
+    out->addColumn<float>("srcHwSigmaetaeta", vals_hw_sigmaetaeta, "");
+    out->addColumn<float>("srcSigmaphiphi", vals_sigmaphiphi, "");
+    out->addColumn<float>("srcHwSigmaphiphi", vals_hw_sigmaphiphi, "");
+    out->addColumn<float>("srcSigmazz", vals_sigmazz, "");
+    out->addColumn<float>("srcHwSigmazz", vals_hw_sigmazz, "");
+    out->addColumn<float>("srcPt", vals_caloPt, "");
+    out->addColumn<float>("srcEta", vals_caloEta, "");
+    out->addColumn<float>("srcPhi", vals_caloPhi, "");
     // save to the event branches
     iEvent.put(std::move(out));
 

--- a/NtupleProducer/plugins/L1PFTkEleTableProducer.cc
+++ b/NtupleProducer/plugins/L1PFTkEleTableProducer.cc
@@ -1,0 +1,107 @@
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+
+#include "DataFormats/L1TCorrelator/interface/TkElectron.h"
+#include "DataFormats/L1TCorrelator/interface/TkElectronFwd.h"
+#include "DataFormats/L1TParticleFlow/interface/egamma.h"
+
+#include <algorithm>
+
+class L1PFTkEleTableProducer : public edm::global::EDProducer<> {
+public:
+    explicit L1PFTkEleTableProducer(const edm::ParameterSet&);
+    ~L1PFTkEleTableProducer() override = default;
+
+private:
+    void produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+
+    std::string name_;
+    edm::EDGetTokenT<edm::View<l1t::TkElectron>> src_;
+    StringCutObjectSelector<l1t::TkElectron> sel_;
+};
+
+L1PFTkEleTableProducer::L1PFTkEleTableProducer(const edm::ParameterSet& iConfig)
+    : name_(iConfig.getParameter<std::string>("name")),
+      src_(consumes<edm::View<l1t::TkElectron>>(iConfig.getParameter<edm::InputTag>("src"))),
+      sel_(iConfig.getParameter<std::string>("cut"), true) {
+    produces<nanoaod::FlatTable>();
+}
+
+void L1PFTkEleTableProducer::produce(edm::StreamID id,
+                                     edm::Event& iEvent,
+                                     const edm::EventSetup& iSetup) const {
+    edm::Handle<edm::View<l1t::TkElectron>> src;
+    iEvent.getByToken(src_, src);
+
+    std::vector<const l1t::TkElectron*> selected;
+    for (const auto& ele : *src)
+        if (sel_(ele))
+            selected.push_back(&ele);
+
+    unsigned int ncands = selected.size();
+    auto out = std::make_unique<nanoaod::FlatTable>(ncands, name_, false, true);
+
+    std::vector<float> hwPt(ncands, 0), hwEta(ncands, 0), hwPhi(ncands, 0),
+        hwQual(ncands, 0), hwIso(ncands, 0),
+        hwDEta(ncands, 0), hwDPhi(ncands, 0), hwZ0(ncands, 0),
+        hwCharge(ncands, 0), hwIDScore(ncands, 0),
+        hwTkRedChi2RPhi(ncands, 0), hwTkCaloDphi(ncands, 0),
+        hwCaloShowerShape(ncands, 0), hwCaloTkPtRatio(ncands, 0);
+
+    for (unsigned int i = 0; i < ncands; ++i) {
+        const auto& ele = *selected[i];
+        if (ele.encoding() != l1t::TkEm::HWEncoding::CT)
+            continue;
+
+        auto word = ele.egBinaryWord<l1ct::EGIsoEleObj::BITWIDTH>();
+        l1ct::EGIsoEleObj ct;
+        ct.initFromBits(word);
+
+        hwPt[i]              = ct.hwPt.to_float();
+        hwEta[i]             = ct.hwEta.to_float();
+        hwPhi[i]             = ct.hwPhi.to_float();
+        hwQual[i]            = float(ct.hwQual);
+        hwIso[i]             = ct.hwIso.to_float();
+        hwDEta[i]            = ct.hwDEta.to_float();
+        hwDPhi[i]            = ct.hwDPhi.to_float();
+        hwZ0[i]              = ct.hwZ0.to_float();
+        hwCharge[i]          = float(ct.hwCharge);
+        hwIDScore[i]         = ct.hwIDScore.to_float();
+        hwTkRedChi2RPhi[i]   = ct.hwTkRedChi2RPhi.to_float();
+        hwTkCaloDphi[i]      = ct.hwTkCaloDphi.to_float();
+        hwCaloShowerShape[i] = ct.hwCaloShowerShape.to_float();
+        hwCaloTkPtRatio[i]   = ct.hwCaloTkPtRatio.to_float();
+    }
+
+    out->addColumn<float>("hwPt",              hwPt,              "CT hardware pT [LSB = 0.25 GeV]");
+    out->addColumn<float>("hwEta",             hwEta,             "CT hardware eta at calo face [LSB = pi/720]");
+    out->addColumn<float>("hwPhi",             hwPhi,             "CT hardware phi at calo face [LSB = pi/720]");
+    out->addColumn<float>("hwQual",            hwQual,            "CT hardware quality flags");
+    out->addColumn<float>("hwIso",             hwIso,             "CT hardware isolation pT [LSB = 0.25 GeV]");
+    out->addColumn<float>("hwDEta",            hwDEta,            "CT hardware track-calo delta eta [LSB = pi/720]");
+    out->addColumn<float>("hwDPhi",            hwDPhi,            "CT hardware track-calo delta phi [LSB = pi/720]");
+    out->addColumn<float>("hwZ0",              hwZ0,              "CT hardware track z0 [LSB = 0.05 cm]");
+    out->addColumn<float>("hwCharge",          hwCharge,          "CT hardware charge (1=positive, 0=negative)");
+    out->addColumn<float>("hwIDScore",         hwIDScore,         "CT hardware ID score [-1, 1]");
+    out->addColumn<float>("hwTkRedChi2RPhi",   hwTkRedChi2RPhi,   "CT hardware track reduced chi2 in R-phi (4-bit bin)");
+    out->addColumn<float>("hwTkCaloDphi",      hwTkCaloDphi,      "CT hardware track-calo delta phi (7 bits)");
+    out->addColumn<float>("hwCaloShowerShape", hwCaloShowerShape, "CT hardware calo shower shape (6 bits)");
+    out->addColumn<float>("hwCaloTkPtRatio",   hwCaloTkPtRatio,   "CT hardware calo/track pT ratio (10 bits)");
+
+    iEvent.put(std::move(out));
+}
+
+//define this as a plug-in
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(L1PFTkEleTableProducer);

--- a/NtupleProducer/python/runPerformanceNTuple.py
+++ b/NtupleProducer/python/runPerformanceNTuple.py
@@ -258,7 +258,10 @@ def addCalib():
     process.l1tLayer1BarrelRaw = process.l1tLayer1Barrel.clone(
         gctEmInputConversionParameters = process.l1tLayer1Barrel.gctEmInputConversionParameters.clone(
             gctEmCorrector = cms.string("")
-        )
+        ),
+        gctHadInputConversionParameters = process.l1tLayer1Barrel.gctHadInputConversionParameters.clone(
+            gctHadCorrector = cms.string("")
+        ),
     )
 
 
@@ -281,7 +284,7 @@ def addCalib():
 
     #uncalibrated
     process.ntuple.objects.L1RawBarrelEcal   = cms.VInputTag('l1tLayer1BarrelRaw:DecodedEmClusters')
-    process.ntuple.objects.L1RawBarrelCalo   = cms.VInputTag('l1tPFClustersFromCombinedCaloHCal:uncalibrated')
+    process.ntuple.objects.L1RawBarrelCalo   = cms.VInputTag('ll1tLayer1BarrelRaw:DecodedHadClusters')
     process.ntuple.objects.L1RawHGCal   = cms.VInputTag('l1tLayer1HGCalRaw:DecodedHadClusters', 'l1tLayer1HGCalNoTKRaw:DecodedHadClusters')#use only this, try to understand if you have to use emf or emf_tot
     process.ntuple.objects.L1RawHGCalEM = cms.VInputTag('l1tLayer1HGCalRaw:DecodedEmClusters', 'l1tLayer1HGCalNoTKRaw:DecodedEmClusters')
     process.ntuple.objects.L1RawHFCalo  = cms.VInputTag('l1tPFClustersFromCombinedCaloHF:uncalibrated')

--- a/NtupleProducer/python/runPerformanceNTuple.py
+++ b/NtupleProducer/python/runPerformanceNTuple.py
@@ -16,7 +16,7 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1))
 process.MessageLogger.cerr.FwkReport.reportEvery = 1
 
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('file:inputs125X.root'),
+    fileNames = cms.untracked.vstring('file:inputs140X.root'),
     inputCommands = cms.untracked.vstring("keep *", 
             "drop l1tPFClusters_*_*_*",
             "drop l1tPFTracks_*_*_*",
@@ -52,6 +52,10 @@ process.l1tPhase2CaloPFClusterEmulator = l1tPhase2CaloPFClusterEmulator.clone()
 from L1Trigger.L1CaloTrigger.l1tPhase2GCTBarrelToCorrelatorLayer1Emulator_cfi import l1tPhase2GCTBarrelToCorrelatorLayer1Emulator
 process.l1tPhase2GCTBarrelToCorrelatorLayer1Emulator = l1tPhase2GCTBarrelToCorrelatorLayer1Emulator.clone()
 
+from L1Trigger.L1CaloTrigger.l1tPhase2CaloToCorrelatorTM18_cfi import l1tPhase2CaloToCorrelatorTM18
+process.l1tPhase2CaloToCorrelatorTM18 = l1tPhase2CaloToCorrelatorTM18.clone()
+
+
 from L1Trigger.Phase2L1ParticleFlow.L1NNTauProducer_cff import l1tNNTauProducerPuppi
 process.l1tNNTauProducerPuppi = l1tNNTauProducerPuppi.clone()
 
@@ -63,6 +67,7 @@ process.extraPFStuff = cms.Task(
         process.l1tPhase2L1CaloEGammaEmulator,
         process.l1tPhase2CaloPFClusterEmulator,
         process.l1tPhase2GCTBarrelToCorrelatorLayer1Emulator,
+        process.l1tPhase2CaloToCorrelatorTM18,
         process.l1tSAMuonsGmt,
         process.l1tGTTInputProducer,
         process.l1tTrackSelectionProducer,
@@ -388,6 +393,7 @@ def addGen(pdgs):
                     vz   = Var("vz",  float,precision=8),
                     charge  = Var("charge", int, doc="charge id"),
                     prompt  = Var("2*statusFlags().isPrompt() + statusFlags().isDirectPromptTauDecayProduct()", int, doc="Particle status."),
+                    pdgId  = Var("pdgId", int, doc="PDG id")
                 )
             )
     genLepTableExt = cms.EDProducer("L1PFGenTableProducer",
@@ -430,6 +436,17 @@ def addGen(pdgs):
                         name = process.genPiTable.name
             )
             process.extraPFStuff.add(process.genPiTable, process.genPiExtTable)
+        elif pdgId == 130:
+            process.genK0LTable = genLepTable.clone(
+                        cut  = cms.string("abs(pdgId) == %d && status == 1 && pt > 2" % pdgId),
+                        name = cms.string("GenK0L"))
+            process.genK0LExtTable = genLepTableExt.clone(
+                        cut = process.genK0LTable.cut,
+                        name = process.genK0LTable.name
+            )
+            process.extraPFStuff.add(process.genK0LTable, process.genK0LExtTable)
+        else:
+            raise ValueError("pdgId %d not supported in addGen" % pdgId)
 
 def addGenPi(pdgs=[211]):
     addGen(pdgs)
@@ -742,7 +759,7 @@ def addDecodedCalo(types=['Had', 'Em'], regs=['HGCal','Barrel','HGCalNoTK']):
                                 hwPhi = LazyVar("hwPhi", int, doc="hwPhi"),
                             )
                         )            
-
+                                                                    
             decCaloTableExt = cms.EDProducer("L1PFDecodedCaloTableProducer",
                                              src = cms.InputTag("l1tLayer1"+reg, f'Decoded{tp}Clusters'),
                                              name = cms.string(""),
@@ -852,3 +869,6 @@ def saveGenCands():
                                            ),
                                       )
     process.p += process.gencandTable
+
+
+# addDecodedCalo()

--- a/NtupleProducer/python/runPerformanceNTuple.py
+++ b/NtupleProducer/python/runPerformanceNTuple.py
@@ -657,19 +657,27 @@ def addTkEG(doL1=False, doL2=True, postfix=""):
         tkEleTable.variables.caloEta = LazyVar("egCaloPtr.eta", float,precision=8)
         tkEleTable.variables.caloPhi = LazyVar("egCaloPtr.phi", float,precision=8)
 
-        return tkEmTable, tkEleTable
+        tkEleTableExt = cms.EDProducer("L1PFTkEleTableProducer",
+                                        src = cms.InputTag(tkele_inputtag),
+                                        name = cms.string("TkEle"+slice+postfix),
+                                        cut = cms.string(""),)
+
+        return tkEmTable, tkEleTable, tkEleTableExt
                                    
     if doL1:    
         for w in "EB","EE":
-            tkEmTable, tkEleTable = getTkEgTables(w, postfix, f"l1tLayer1EG{postfix}:L1TkEm{w}", f'l1tLayer1EG{postfix}:L1TkEle{w}')
+            tkEmTable, tkEleTable, tkEleTableExt = getTkEgTables(w, postfix, f"l1tLayer1EG{postfix}:L1TkEm{w}", f'l1tLayer1EG{postfix}:L1TkEle{w}')
             setattr(process, "TkEm%s%sTable" % (w,postfix), tkEmTable)
             setattr(process, "TkEle%s%sTable" % (w,postfix), tkEleTable)
-            process.extraPFStuff.add(tkEmTable,tkEleTable)
+            setattr(process, "TkEle%s%sExtTable" % (w,postfix), tkEleTableExt)
+
+            process.extraPFStuff.add(tkEmTable,tkEleTable,tkEleTableExt)
 
     if doL2:    
-        tkEmTable, tkEleTable = getTkEgTables('L2', postfix, f"l1tLayer2EG:L1CtTkEm", f'l1tLayer2EG:L1CtTkElectron')
+        tkEmTable, tkEleTable, tkEleTableExt = getTkEgTables('L2', postfix, f"l1tLayer2EG:L1CtTkEm", f'l1tLayer2EG:L1CtTkElectron')
         setattr(process, "TkEmL2%sTable" % (postfix), tkEmTable)
         setattr(process, "TkEleL2%sTable" % (postfix), tkEleTable)
+        # setattr(process, "TkEleL2%sExtTable" % (postfix), tkEleTableExt)
         process.extraPFStuff.add(tkEmTable,tkEleTable)
 
 


### PR DESCRIPTION

* Update configuration to use new GCT input objects with TMUX18 link config
* Add source quantities to decoded calo objects for direct comparison
* Add hw quantities to TkElectron tables